### PR TITLE
Make glide install a one time local step

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
-vendor
 .git
 .idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,8 @@ FROM glider as stage0
 
 RUN mkdir -p "$GOPATH/src/github.com/andrecronje/lachesis" /cp_bin /bin
 COPY . "$GOPATH/src/github.com/andrecronje/lachesis"
-RUN cd "$GOPATH/src/github.com/andrecronje/lachesis" && \
-    rm -rf vendor && \
-    glide install && \
-    cd "$GOPATH/src/github.com/andrecronje/lachesis/cmd/lachesis" && \
+
+RUN cd "$GOPATH/src/github.com/andrecronje/lachesis/cmd/lachesis" && \
     go build -ldflags "-linkmode external -extldflags -static -s -w" -a main.go && \
     mv "$GOPATH/src/github.com/andrecronje/lachesis/cmd/lachesis/main" /cp_bin/lachesis
 

--- a/docker/builder/install_deps.bash
+++ b/docker/builder/install_deps.bash
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Do a glide install if vendor directory does not exist
+[[ -d vendor ]] || glide install
+

--- a/docker/builder/scale.bash
+++ b/docker/builder/scale.bash
@@ -11,6 +11,9 @@ ip_start="${ip_start:-192.168.0.2}"
 subnet="${subnet:-16}"
 ip_range="$ip_start/$subnet"
 
+# Do a glide install if vendor directory does not exist
+[[ -d vendor ]] || glide install
+
 # Run
 batch-ethkey -dir "$BUILD_DIR/nodes" -network "$ip_start" -n "$n" > "$PEERS_DIR/peers.json"
 docker build --compress --force-rm --tag "$PROJECT" "$BUILD_DIR"

--- a/docker/builder/scale.bash
+++ b/docker/builder/scale.bash
@@ -11,8 +11,8 @@ ip_start="${ip_start:-192.168.0.2}"
 subnet="${subnet:-16}"
 ip_range="$ip_start/$subnet"
 
-# Do a glide install if vendor directory does not exist
-[[ -d vendor ]] || glide install
+# Install deps
+"$DIR/install_deps.bash"
 
 # Run
 batch-ethkey -dir "$BUILD_DIR/nodes" -network "$ip_start" -n "$n" > "$PEERS_DIR/peers.json"

--- a/docker/builder/spin.bash
+++ b/docker/builder/spin.bash
@@ -4,6 +4,8 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 . "$DIR/set_globals.bash"
 
+"$DIR/install_deps.bash"
+
 node_num="$1"
 ip="$2"
 container="$PROJECT$node_num"


### PR DESCRIPTION
This only runs `glide install` locally when the `vendor` directory doesn't exist. The go code is instead copied into the docker image, rather than downloaded each time the image is built.