### PR TITLE
fix for import cycle

### DIFF
--- a/cmd/lachesis/commands/run.go
+++ b/cmd/lachesis/commands/run.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"github.com/andrecronje/lachesis/src/lachesis"
+	"github.com/andrecronje/lachesis/src/log"
 	aproxy "github.com/andrecronje/lachesis/src/proxy/app"
 	"github.com/andrecronje/lachesis/tester"
 	"github.com/sirupsen/logrus"
@@ -59,6 +60,11 @@ func NewRunCmd() *cobra.Command {
 func logConfig(cmd *cobra.Command, args []string) error {
 	config.Lachesis.Logger.Level = lachesis.LogLevel(config.Lachesis.LogLevel)
 	config.Lachesis.NodeConfig.Logger = config.Lachesis.Logger
+
+	levels := map[string]bool {"debug": true, "error": true, "fatal": true, "panic" : true, "warn": true}
+	if _, exist := levels[config.Lachesis.LogLevel]; exist {
+		lachesis_log.NewLocal(config.Lachesis.Logger)
+	}
 
 	config.Lachesis.Logger.WithFields(logrus.Fields{
 		"proxy-listen":   config.ProxyAddr,

--- a/src/lachesis/lachesis_config.go
+++ b/src/lachesis/lachesis_config.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/andrecronje/lachesis/src/log"
 	"github.com/andrecronje/lachesis/src/node"
 	"github.com/andrecronje/lachesis/src/proxy"
 	aproxy "github.com/andrecronje/lachesis/src/proxy/app"
@@ -51,7 +50,6 @@ func NewDefaultConfig() *LachesisConfig {
 	}
 
 	config.Logger.Level = LogLevel(config.LogLevel)
-	lachesis_log.NewLocal(config.Logger)
 	config.Proxy = aproxy.NewInmemAppProxy(config.Logger)
 	config.NodeConfig.Logger = config.Logger
 

--- a/src/log/hook.go
+++ b/src/log/hook.go
@@ -4,9 +4,7 @@
 package lachesis_log
 
 import (
-	"github.com/andrecronje/lachesis/src/lachesis"
 	"runtime/debug"
-	"sort"
 	"sync"
 	"time"
 
@@ -22,10 +20,7 @@ type Hook struct {
 
 // NewLocal installs a test hook for a given local logger.
 func NewLocal(logger *logrus.Logger) {
-	levels := []string{"debug", "error", "fatal", "panic", "warn"}
-	if sort.SearchStrings(levels, lachesis.Config.LogLevel) != len(levels) {
-		logger.Hooks.Add(new(Hook))
-	}
+	logger.Hooks.Add(new(Hook))
 }
 
 func (t *Hook) Fire(e *logrus.Entry) error {


### PR DESCRIPTION
I found a solution: move log level check into commands/run.go