### PR TITLE
Fix tests

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 668cb5e68dbc36438d41672e0d54f13b88518ee01f59497d8cd9540865dce802
-updated: 2018-10-18T15:34:03.332246211+11:00
+hash: 69dccafc2b2374c18438f844fb6648fe8a9dfba75b1e9dce11dabfaed9e6d0f2
+updated: 2018-10-22T17:52:21.308104214-04:00
 imports:
 - name: github.com/AndreasBriese/bbloom
   version: 343706a395b76e5ca5c7dca46a5d937b48febc74
@@ -52,8 +52,10 @@ imports:
   version: 81a861c69d25a841d0c4394f0e6f84bc8c5afae0
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
+- name: github.com/rifflock/lfshook
+  version: b9218ef580f59a2e72dad1aa33d660150445d05a
 - name: github.com/satori/go.uuid
-  version: 36e9d2ebbde5e3f13ab2e25625fd453271d6522e
+  version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/sirupsen/logrus
   version: ad15b42461921f1fb3529b058c6786c6a45d5162
 - name: github.com/spf13/afero

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,6 @@ import:
   version: ^1.2.0
 - package: github.com/sirupsen/logrus
   version: ^1.1.1
-- package: github.com/rifflock/lfshook
 - package: github.com/spf13/cobra
   version: ^0.0.3
 - package: github.com/spf13/viper
@@ -19,3 +18,5 @@ import:
   - codec
 - package: github.com/urfave/cli
   version: ^1.20.0
+- package: github.com/rifflock/lfshook
+  version: ^2.4.0

--- a/makefile
+++ b/makefile
@@ -21,7 +21,7 @@ dist:
 	@BUILD_TAGS='$(BUILD_TAGS)' sh -c "'$(CURDIR)/scripts/dist.sh'"
 
 test:
-	glide novendor | xargs go test
+	glide novendor | grep -v -e "^\.$$" | xargs go test
 
 # clean up and generate protobuf files
 proto:

--- a/src/dummy/inapp_dummy_test.go
+++ b/src/dummy/inapp_dummy_test.go
@@ -11,10 +11,7 @@ import (
 )
 
 func TestInappDummySubmit(t *testing.T) {
- 	dummy, err := NewDummyInappClient(common.NewTestLogger(t))
-	if err != nil {
-		t.Fatalf("Cannot create DummyInappClient: %s", err)
-	}
+ 	dummy := NewDummyInappClient(common.NewTestLogger(t))
  	submitCh := dummy.proxy.SubmitCh()
  	tx := []byte("the test transaction")
  	// Listen for a request
@@ -29,17 +26,14 @@ func TestInappDummySubmit(t *testing.T) {
 			t.Fatalf("timeout")
 		}
 	}()
- 	err = dummy.SubmitTx(tx)
+	err := dummy.SubmitTx(tx)
  	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestInappDummyCommitAndSnapshots(t *testing.T) {
- 	dummy, err := NewDummyInappClient(common.NewTestLogger(t))
-	if err != nil {
-		t.Fatalf("Cannot create DummyInappClient: %s", err)
-	}
+ 	dummy := NewDummyInappClient(common.NewTestLogger(t))
  	initialStateHash := []byte{}
  	//create a few blocks
 	blocks := [5]poset.Block{}

--- a/src/dummy/inmem_dummy_test.go
+++ b/src/dummy/inmem_dummy_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
  	"github.com/andrecronje/lachesis/src/common"
 	bcrypto "github.com/andrecronje/lachesis/src/crypto"
-	"github.com/andrecronje/lachesis/src/poset"
 )
 
 func TestInmemDummyAppSide(t *testing.T) {

--- a/src/mobile/mobile_app_proxy.go
+++ b/src/mobile/mobile_app_proxy.go
@@ -1,8 +1,6 @@
 package mobile
 
 import (
-	"time"
-
 	"github.com/andrecronje/lachesis/src/poset"
 	"github.com/andrecronje/lachesis/src/proxy/inmem"
 	"github.com/sirupsen/logrus"

--- a/src/net/mqtt.go
+++ b/src/net/mqtt.go
@@ -24,7 +24,7 @@ func NewMqttSocket(host string, callback mqtt.MessageHandler) *MqttSocket {
 	options.OnConnectionLost = func(client mqtt.Client, e error) {
 		// MQTT client connection lost with server
 	}
-	cliID, _ := uuid.NewV4()
+	cliID := uuid.NewV4()
 	options.SetClientID(cliID.String())
 	options.SetDefaultPublishHandler(callback)
 	return &MqttSocket{

--- a/src/proxy/inmem/inmem_proxy_test.go
+++ b/src/proxy/inmem/inmem_proxy_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
  	"github.com/andrecronje/lachesis/src/common"
 	"github.com/andrecronje/lachesis/src/poset"
+	"github.com/sirupsen/logrus"
 )
 
 type TestProxy struct {

--- a/src/service/service.go
+++ b/src/service/service.go
@@ -101,7 +101,7 @@ func (s *Service) GetLastEventFrom(w http.ResponseWriter, r *http.Request) {
 	param := r.URL.Path[len("/lasteventfrom/"):]
 	event, _, err := s.node.GetLastEventFrom(param)
 	if err != nil {
-		s.logger.WithError(err).Errorf("Retrieving event %d", event)
+		s.logger.WithError(err).Errorf("Retrieving event %s", event)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -185,7 +185,7 @@ func (s *Service) GetRoot(w http.ResponseWriter, r *http.Request) {
 	param := r.URL.Path[len("/root/"):]
 	root, err := s.node.GetRoot(param)
 	if err != nil {
-		s.logger.WithError(err).Errorf("Retrieving root %d", param)
+		s.logger.WithError(err).Errorf("Retrieving root %s", param)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -24,7 +24,7 @@ func PingNodesN(participants []*peers.Peer, p peers.PubKeyPeers, n uint64, servi
 
 		if err != nil {
 			fmt.Printf("error:\t\t\t%s\n", err.Error())
-			fmt.Printf("Failed to ping:\t\t\t%s (id=%d)\n", participant.NetAddr, node)
+			fmt.Printf("Failed to ping:\t\t\t%s (id=%d)\n", participant.NetAddr, node.ID)
 			fmt.Printf("Failed to send transaction:\t%d\n\n", iteration)
 		} /*else {
 			fmt.Printf("Pinged:\t\t\t%s (id=%d)\n", participant.NetAddr, node)


### PR DESCRIPTION
The main problem that this fixes is the unability to run `make test`.
Before this fix, it'd fail with this error:

```
can't load package: package github.com/andrecronje/lachesis: build constraints exclude all Go files in /opt/go/src/github.com/andrecronje/lachesis
```

The problem was that in the context of the makefile, `glide novendor`
would return the following output:

```
./cmd/...
./src/...
./test/...
.
```

When you try to pass the fourth line, `.`, to `xargs`, that would upset
go, it's not the kind of directory it would accept. As a quick patch, I
removed from the ouput of `glide novendor` all the references to `.`.

I also noticed some misconfigurations. The main one is that the lack of
version in the `lfshook` package would prevent it from being added into
the vendor folder, causing a bunch of weird to errors: Because it wasn't
in vendor, it would `go` would get the version in github and consider
the types there different from the types in the packages that depend
from `lfshook` but are in `vendor`.

I also fixed a bunch of tests that were happening. I didn't fix all of
them, as the majority seemed to be caused by in progress test for which
I don't have enough context nor knowledge (yet) to be able to fix them.