### PR TITLE
Correctly clean state

### DIFF
--- a/scripts/multi_run.bash
+++ b/scripts/multi_run.bash
@@ -26,7 +26,7 @@ for ip in $(jq -rc '.[].NetAddr' "$PEERS_DIR/lachesis_data_dir/peers.json"); do
 done
 
 # Run multi lachesis
+declare -i rc=1
+trap "rm -rf $BUILD_DIR/lachesis_data_dir/; exit $rc" EXIT QUIT INT
 GOMAXPROCS=$(($logicalCpuCount - 1)) "$BUILD_DIR/lachesis_$TARGET_OS" run --datadir "$BUILD_DIR/lachesis_data_dir" --store --listen="$node_addr":12000 --log=warn --heartbeat=5s -p "$node_addr":9000 --test --test_n=10000
-declare -i rc=$?
-rm -rf "$BUILD_DIR/lachesis_data_dir/"
-exit "$rc"
+rc=$?


### PR DESCRIPTION
If the process doesn't end cleanly, it may keep the `lachesis_data_dir`
around, which will force a failure in the next run. Trapping events,
instead, will make sure everything gets cleaned.