### PR TITLE
Issue #55, #60: int -> int64

### DIFF
--- a/cmd/lachesis/commands/run.go
+++ b/cmd/lachesis/commands/run.go
@@ -132,7 +132,7 @@ func AddRunFlags(cmd *cobra.Command) {
 
 	// Node configuration
 	cmd.Flags().Duration("heartbeat", config.Lachesis.NodeConfig.HeartbeatTimeout, "Time between gossips")
-	cmd.Flags().Int("sync-limit", config.Lachesis.NodeConfig.SyncLimit, "Max number of events for sync")
+	cmd.Flags().Int64("sync-limit", config.Lachesis.NodeConfig.SyncLimit, "Max number of events for sync")
 
 	// Test
 	cmd.Flags().Bool("test", config.Lachesis.Test, "Enable testing (sends transactions to random nodes in the network)")

--- a/src/common/rolling_index.go
+++ b/src/common/rolling_index.go
@@ -5,7 +5,7 @@ import "strconv"
 type RollingIndex struct {
 	name      string
 	size      int
-	lastIndex int
+	lastIndex int64
 	items     []interface{}
 }
 
@@ -18,22 +18,22 @@ func NewRollingIndex(name string, size int) *RollingIndex {
 	}
 }
 
-func (r *RollingIndex) GetLastWindow() (lastWindow []interface{}, lastIndex int) {
+func (r *RollingIndex) GetLastWindow() (lastWindow []interface{}, lastIndex int64) {
 	return r.items, r.lastIndex
 }
 
-func (r *RollingIndex) Get(skipIndex int) ([]interface{}, error) {
+func (r *RollingIndex) Get(skipIndex int64) ([]interface{}, error) {
 	res := make([]interface{}, 0)
 
 	if skipIndex > r.lastIndex {
 		return res, nil
 	}
 
-	cachedItems := len(r.items)
+	cachedItems := int64(len(r.items))
 	//assume there are no gaps between indexes
 	oldestCachedIndex := r.lastIndex - cachedItems + 1
 	if skipIndex+1 < oldestCachedIndex {
-		return res, NewStoreErr(r.name, TooLate, strconv.Itoa(skipIndex))
+		return res, NewStoreErr(r.name, TooLate, strconv.FormatInt(skipIndex, 10))
 	}
 
 	//index of 'skipped' in RollingIndex
@@ -42,25 +42,25 @@ func (r *RollingIndex) Get(skipIndex int) ([]interface{}, error) {
 	return r.items[start:], nil
 }
 
-func (r *RollingIndex) GetItem(index int) (interface{}, error) {
-	items := len(r.items)
+func (r *RollingIndex) GetItem(index int64) (interface{}, error) {
+	items := int64(len(r.items))
 	oldestCached := r.lastIndex - items + 1
 	if index < oldestCached {
-		return nil, NewStoreErr(r.name, TooLate, strconv.Itoa(index))
+		return nil, NewStoreErr(r.name, TooLate, strconv.FormatInt(index, 10))
 	}
 	findex := index - oldestCached
 	if findex >= items {
-		return nil, NewStoreErr(r.name, KeyNotFound, strconv.Itoa(index))
+		return nil, NewStoreErr(r.name, KeyNotFound, strconv.FormatInt(index, 10))
 	}
 	return r.items[findex], nil
 }
 
-func (r *RollingIndex) Set(item interface{}, index int) error {
+func (r *RollingIndex) Set(item interface{}, index int64) error {
 
 	//only allow to set items with index <= lastIndex + 1
 	//so that we may assume there are no gaps between items
 	if 0 <= r.lastIndex && index > r.lastIndex+1 {
-		return NewStoreErr(r.name, SkippedIndex, strconv.Itoa(index))
+		return NewStoreErr(r.name, SkippedIndex, strconv.FormatInt(index, 10))
 	}
 
 	//adding a new item
@@ -75,11 +75,11 @@ func (r *RollingIndex) Set(item interface{}, index int) error {
 
 	//replace and existing item
 	//make sure index is also greater or equal than the oldest cached item's index
-	cachedItems := len(r.items)
+	cachedItems := int64(len(r.items))
 	oldestCachedIndex := r.lastIndex - cachedItems + 1
 
 	if index < oldestCachedIndex {
-		return NewStoreErr(r.name, TooLate, strconv.Itoa(index))
+		return NewStoreErr(r.name, TooLate, strconv.FormatInt(index, 10))
 	}
 
 	//replacing existing item

--- a/src/common/rolling_index_map.go
+++ b/src/common/rolling_index_map.go
@@ -8,12 +8,12 @@ import (
 type RollingIndexMap struct {
 	name    string
 	size    int
-	keys    []int
-	mapping map[int]*RollingIndex
+	keys    []int64
+	mapping map[int64]*RollingIndex
 }
 
-func NewRollingIndexMap(name string, size int, keys []int) *RollingIndexMap {
-	items := make(map[int]*RollingIndex)
+func NewRollingIndexMap(name string, size int, keys []int64) *RollingIndexMap {
+	items := make(map[int64]*RollingIndex)
 	for _, key := range keys {
 		items[key] = NewRollingIndex(fmt.Sprintf("%s[%d]", name, key), size)
 	}
@@ -26,10 +26,10 @@ func NewRollingIndexMap(name string, size int, keys []int) *RollingIndexMap {
 }
 
 //return key items with index > skip
-func (rim *RollingIndexMap) Get(key int, skipIndex int) ([]interface{}, error) {
+func (rim *RollingIndexMap) Get(key int64, skipIndex int64) ([]interface{}, error) {
 	items, ok := rim.mapping[key]
 	if !ok {
-		return nil, NewStoreErr(rim.name, KeyNotFound, strconv.Itoa(key))
+		return nil, NewStoreErr(rim.name, KeyNotFound, strconv.FormatInt(key, 10))
 	}
 
 	cached, err := items.Get(skipIndex)
@@ -40,14 +40,14 @@ func (rim *RollingIndexMap) Get(key int, skipIndex int) ([]interface{}, error) {
 	return cached, nil
 }
 
-func (rim *RollingIndexMap) GetItem(key int, index int) (interface{}, error) {
+func (rim *RollingIndexMap) GetItem(key int64, index int64) (interface{}, error) {
 	return rim.mapping[key].GetItem(index)
 }
 
-func (rim *RollingIndexMap) GetLast(key int) (interface{}, error) {
+func (rim *RollingIndexMap) GetLast(key int64) (interface{}, error) {
 	pe, ok := rim.mapping[key]
 	if !ok {
-		return nil, NewStoreErr(rim.name, KeyNotFound, strconv.Itoa(key))
+		return nil, NewStoreErr(rim.name, KeyNotFound, strconv.FormatInt(key, 10))
 	}
 	cached, _ := pe.GetLastWindow()
 	if len(cached) == 0 {
@@ -56,7 +56,7 @@ func (rim *RollingIndexMap) GetLast(key int) (interface{}, error) {
 	return cached[len(cached)-1], nil
 }
 
-func (rim *RollingIndexMap) Set(key int, item interface{}, index int) error {
+func (rim *RollingIndexMap) Set(key int64, item interface{}, index int64) error {
 	items, ok := rim.mapping[key]
 	if !ok {
 		items = NewRollingIndex(fmt.Sprintf("%s[%d]", rim.name, key), rim.size)
@@ -66,8 +66,8 @@ func (rim *RollingIndexMap) Set(key int, item interface{}, index int) error {
 }
 
 //returns [key] => lastKnownIndex
-func (rim *RollingIndexMap) Known() map[int]int {
-	known := make(map[int]int)
+func (rim *RollingIndexMap) Known() map[int64]int64 {
+	known := make(map[int64]int64)
 	for k, items := range rim.mapping {
 		_, lastIndex := items.GetLastWindow()
 		known[k] = lastIndex
@@ -76,7 +76,7 @@ func (rim *RollingIndexMap) Known() map[int]int {
 }
 
 func (rim *RollingIndexMap) Reset() error {
-	items := make(map[int]*RollingIndex)
+	items := make(map[int64]*RollingIndex)
 	for _, key := range rim.keys {
 		items[key] = NewRollingIndex(fmt.Sprintf("%s[%d]", rim.name, key), rim.size)
 	}

--- a/src/common/rolling_index_test.go
+++ b/src/common/rolling_index_test.go
@@ -8,10 +8,10 @@ import (
 
 func TestRollingIndex(t *testing.T) {
 	size := 10
-	testSize := 3 * size
+	testSize := int64(3 * size)
 	RollingIndex := NewRollingIndex("test", size)
 	items := []string{}
-	for i := 0; i < testSize; i++ {
+	for i := int64(0); i < testSize; i++ {
 		item := fmt.Sprintf("item%d", i)
 		RollingIndex.Set(item, i)
 		items = append(items, item)
@@ -23,10 +23,10 @@ func TestRollingIndex(t *testing.T) {
 		t.Fatalf("lastIndex should be %d, not %d", expectedLastIndex, lastIndex)
 	}
 
-	start := (testSize / (2 * size)) * (size)
+	start := (testSize / (2 * int64(size))) * int64(size)
 	count := testSize - start
 
-	for i := 0; i < count; i++ {
+	for i := int64(0); i < count; i++ {
 		if cached[i] != items[start+i] {
 			t.Fatalf("cached[%d] should be %s, not %s", i, items[start+i], cached[i])
 		}
@@ -44,7 +44,7 @@ func TestRollingIndex(t *testing.T) {
 
 	var item interface{}
 
-	indexes := []int{10, 17, 29}
+	indexes := []int64{10, 17, 29}
 	for _, i := range indexes {
 		item, err = RollingIndex.GetItem(i)
 		if err != nil {
@@ -61,7 +61,7 @@ func TestRollingIndex(t *testing.T) {
 	}
 
 	//Test updating an item in place
-	updateIndex := 26
+	updateIndex := int64(26)
 	updateValue := "Updated Item"
 
 	err = RollingIndex.Set(updateValue, updateIndex)
@@ -80,7 +80,7 @@ func TestRollingIndex(t *testing.T) {
 
 func TestRollingIndexSkip(t *testing.T) {
 	size := 10
-	testSize := 25
+	testSize := int64(25)
 	RollingIndex := NewRollingIndex("test", size)
 
 	_, err := RollingIndex.Get(-1)
@@ -89,7 +89,7 @@ func TestRollingIndexSkip(t *testing.T) {
 	}
 
 	items := []string{}
-	for i := 0; i < testSize; i++ {
+	for i := int64(0); i < testSize; i++ {
 		item := fmt.Sprintf("item%d", i)
 		RollingIndex.Set(item, i)
 		items = append(items, item)
@@ -99,7 +99,7 @@ func TestRollingIndexSkip(t *testing.T) {
 		t.Fatalf("Skipping index 0 should return ErrTooLate")
 	}
 
-	skipIndex1 := 9
+	skipIndex1 := int64(9)
 	expected1 := items[skipIndex1+1:]
 	cached1, err := RollingIndex.Get(skipIndex1)
 	if err != nil {
@@ -113,7 +113,7 @@ func TestRollingIndexSkip(t *testing.T) {
 		t.Fatalf("expected and cached not equal")
 	}
 
-	skipIndex2 := 15
+	skipIndex2 := int64(15)
 	expected2 := items[skipIndex2+1:]
 	cached2, err := RollingIndex.Get(skipIndex2)
 	if err != nil {
@@ -127,7 +127,7 @@ func TestRollingIndexSkip(t *testing.T) {
 		t.Fatalf("expected and cached not equal")
 	}
 
-	skipIndex3 := 27
+	skipIndex3 := int64(27)
 	expected3 := []string{}
 	cached3, err := RollingIndex.Get(skipIndex3)
 	if err != nil {

--- a/src/dummy/client_test.go
+++ b/src/dummy/client_test.go
@@ -76,7 +76,7 @@ func TestDummySocketClient(t *testing.T) {
 	initialStateHash := state.stateHash
 	//create a few blocks
 	blocks := [5]poset.Block{}
-	for i := 0; i < 5; i++ {
+	for i := int64(0); i < 5; i++ {
 		blocks[i] = poset.NewBlock(i, i+1, []byte{}, [][]byte{[]byte(fmt.Sprintf("block %d transaction", i))})
 	}
 

--- a/src/dummy/state.go
+++ b/src/dummy/state.go
@@ -23,7 +23,7 @@ type State struct {
 	logger       *logrus.Logger
 	committedTxs [][]byte
 	stateHash    []byte
-	snapshots    map[int][]byte
+	snapshots    map[int64][]byte
 }
 
 func NewState(logger *logrus.Logger) *State {
@@ -31,7 +31,7 @@ func NewState(logger *logrus.Logger) *State {
 		logger:       logger,
 		committedTxs: [][]byte{},
 		stateHash:    []byte{},
-		snapshots:    make(map[int][]byte),
+		snapshots:    make(map[int64][]byte),
 	}
 	logger.Info("Init Dummy State")
 
@@ -53,7 +53,7 @@ func (s *State) CommitHandler(block poset.Block) ([]byte, error) {
 	return s.stateHash, nil
 }
 
-func (s *State) SnapshotHandler(blockIndex int) ([]byte, error) {
+func (s *State) SnapshotHandler(blockIndex int64) ([]byte, error) {
 	s.logger.WithField("block", blockIndex).Debug("GetSnapshot")
 
 	snapshot, ok := s.snapshots[blockIndex]

--- a/src/mobile/mobile_app_proxy.go
+++ b/src/mobile/mobile_app_proxy.go
@@ -46,7 +46,7 @@ func (m *mobileAppProxy) CommitHandler(block poset.Block) ([]byte, error) {
 	stateHash := m.commitHandler.OnCommit(blockBytes)
 	return stateHash, nil
 }
-func (m *mobileAppProxy) SnapshotHandler(blockIndex int) ([]byte, error) {
+func (m *mobileAppProxy) SnapshotHandler(blockIndex int64) ([]byte, error) {
 	return []byte{}, nil
 }
 func (m *mobileAppProxy) RestoreHandler(snapshot []byte) ([]byte, error) {
@@ -68,7 +68,7 @@ func (p *mobileAppProxy) CommitBlock(block poset.Block) ([]byte, error) {
 }
 
 //TODO - Implement these two functions
-func (p *mobileAppProxy) GetSnapshot(blockIndex int) ([]byte, error) {
+func (p *mobileAppProxy) GetSnapshot(blockIndex int64) ([]byte, error) {
 	return []byte{}, nil
 }
 

--- a/src/mobile/node.go
+++ b/src/mobile/node.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Node struct {
-	nodeID int
+	nodeID int64
 	node   *node.Node
 	proxy  proxy.AppProxy
 	logger *logrus.Logger

--- a/src/net/commands.go
+++ b/src/net/commands.go
@@ -3,37 +3,37 @@ package net
 import "github.com/andrecronje/lachesis/src/poset"
 
 type SyncRequest struct {
-	FromID int
-	Known  map[int]int
+	FromID int64
+	Known  map[int64]int64
 }
 
 type SyncResponse struct {
-	FromID    int
+	FromID    int64
 	SyncLimit bool
 	Events    []poset.WireEvent
-	Known     map[int]int
+	Known     map[int64]int64
 }
 
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 type EagerSyncRequest struct {
-	FromID int
+	FromID int64
 	Events []poset.WireEvent
 }
 
 type EagerSyncResponse struct {
-	FromID  int
+	FromID  int64
 	Success bool
 }
 
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 type FastForwardRequest struct {
-	FromID int
+	FromID int64
 }
 
 type FastForwardResponse struct {
-	FromID   int
+	FromID   int64
 	Block    poset.Block
 	Frame    poset.Frame
 	Snapshot []byte

--- a/src/net/net_transport_test.go
+++ b/src/net/net_transport_test.go
@@ -30,7 +30,7 @@ func TestNetworkTransport_Sync(t *testing.T) {
 	// Make the RPC request
 	args := SyncRequest{
 		FromID: 0,
-		Known: map[int]int{
+		Known: map[int64]int64{
 			0: 1,
 			1: 2,
 			2: 3,
@@ -49,7 +49,7 @@ func TestNetworkTransport_Sync(t *testing.T) {
 				},
 			},
 		},
-		Known: map[int]int{
+		Known: map[int64]int64{
 			0: 5,
 			1: 5,
 			2: 6,
@@ -167,7 +167,7 @@ func TestNetworkTransport_PooledConn(t *testing.T) {
 	// Make the RPC request
 	args := SyncRequest{
 		FromID: 0,
-		Known: map[int]int{
+		Known: map[int64]int64{
 			0: 1,
 			1: 2,
 			2: 3,
@@ -186,7 +186,7 @@ func TestNetworkTransport_PooledConn(t *testing.T) {
 				},
 			},
 		},
-		Known: map[int]int{
+		Known: map[int64]int64{
 			0: 5,
 			1: 5,
 			2: 6,

--- a/src/net/transport_test.go
+++ b/src/net/transport_test.go
@@ -43,7 +43,7 @@ func TestTransport_Sync(t *testing.T) {
 		// Make the RPC request
 		args := SyncRequest{
 			FromID: 0,
-			Known: map[int]int{
+			Known: map[int64]int64{
 				0: 1,
 				1: 2,
 				2: 3,
@@ -62,7 +62,7 @@ func TestTransport_Sync(t *testing.T) {
 					},
 				},
 			},
-			Known: map[int]int{
+			Known: map[int64]int64{
 				0: 5,
 				1: 5,
 				2: 6,

--- a/src/node/config.go
+++ b/src/node/config.go
@@ -13,7 +13,7 @@ type Config struct {
 	HeartbeatTimeout time.Duration `mapstructure:"heartbeat"`
 	TCPTimeout       time.Duration `mapstructure:"timeout"`
 	CacheSize        int           `mapstructure:"cache-size"`
-	SyncLimit        int           `mapstructure:"sync-limit"`
+	SyncLimit        int64         `mapstructure:"sync-limit"`
 	Logger           *logrus.Logger
 	TestDelay uint64 `mapstructure:"test_delay"`
 }
@@ -21,7 +21,7 @@ type Config struct {
 func NewConfig(heartbeat time.Duration,
 	timeout time.Duration,
 	cacheSize int,
-	syncLimit int,
+	syncLimit int64,
 	logger *logrus.Logger) *Config {
 
 	return &Config{

--- a/src/node/core.go
+++ b/src/node/core.go
@@ -16,7 +16,7 @@ import (
 )
 
 type Core struct {
-	id     int
+	id     int64
 	key    *ecdsa.PrivateKey
 	pubKey []byte
 	hexID  string
@@ -26,7 +26,7 @@ type Core struct {
 
 	participants *peers.Peers // [PubKey] => id
 	Head         string
-	Seq          int
+	Seq          int64
 
 	transactionPool    [][]byte
 	blockSignaturePool []poset.BlockSignature
@@ -37,7 +37,7 @@ type Core struct {
 }
 
 func NewCore(
-	id int,
+	id int64,
 	key *ecdsa.PrivateKey,
 	participants *peers.Peers,
 	store poset.Store,
@@ -75,7 +75,7 @@ func NewCore(
 	return core
 }
 
-func (c *Core) ID() int {
+func (c *Core) ID() int64 {
 	return c.id
 }
 
@@ -115,7 +115,7 @@ func (c *Core) InDegrees() map[string]uint64 {
 func (c *Core) SetHeadAndSeq() error {
 
 	var head string
-	var seq int
+	var seq int64
 
 	last, isRoot, err := c.poset.Store.LastEventFrom(c.HexID())
 	if err != nil {
@@ -213,7 +213,7 @@ func (c *Core) InsertEvent(event poset.Event, setWireInfo bool) error {
 	return nil
 }
 
-func (c *Core) KnownEvents() map[int]int {
+func (c *Core) KnownEvents() map[int64]int64 {
 	return c.poset.Store.KnownEvents()
 }
 
@@ -232,8 +232,8 @@ func (c *Core) SignBlock(block poset.Block) (poset.BlockSignature, error) {
 
 // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-func (c *Core) OverSyncLimit(knownEvents map[int]int, syncLimit int) bool {
-	totUnknown := 0
+func (c *Core) OverSyncLimit(knownEvents map[int64]int64, syncLimit int64) bool {
+	totUnknown := int64(0)
 	myKnownEvents := c.KnownEvents()
 	for i, li := range myKnownEvents {
 		if li > knownEvents[i] {
@@ -251,7 +251,7 @@ func (c *Core) GetAnchorBlockWithFrame() (poset.Block, poset.Frame, error) {
 }
 
 // returns events that c knows about and are not in 'known'
-func (c *Core) EventDiff(known map[int]int) (events []poset.Event, err error) {
+func (c *Core) EventDiff(known map[int64]int64) (events []poset.Event, err error) {
 	var unknown []poset.Event
 	// known represents the index of the last event known for every participant
 	// compare this to our view of events and fill unknown with events that we know of
@@ -376,12 +376,12 @@ func (c *Core) AddSelfEventBlock(otherHead string) error {
 	}
 
 	var (
-		flagTable map[string]int
+		flagTable map[string]int64
 		err       error
 	)
 
 	if errSelf != nil {
-		flagTable = map[string]int{c.Head: 1}
+		flagTable = map[string]int64{c.Head: 1}
 	} else {
 		flagTable, err = parentEvent.GetFlagTable()
 		if err != nil {
@@ -390,7 +390,7 @@ func (c *Core) AddSelfEventBlock(otherHead string) error {
 	}
 
 	if errOther == nil {
-		flagTable, err = otherParentEvent.MargeFlagTable(flagTable)
+		flagTable, err = otherParentEvent.MergeFlagTable(flagTable)
 		if err != nil {
 			return fmt.Errorf("failed to marge flag tables: %s", err)
 		}
@@ -523,7 +523,7 @@ func (c *Core) GetConsensusEvents() []string {
 	return c.poset.Store.ConsensusEvents()
 }
 
-func (c *Core) GetConsensusEventsCount() int {
+func (c *Core) GetConsensusEventsCount() int64 {
 	return c.poset.Store.ConsensusEventsCount()
 }
 
@@ -547,7 +547,7 @@ func (c *Core) GetConsensusTransactions() ([][]byte, error) {
 	return txs, nil
 }
 
-func (c *Core) GetLastConsensusRoundIndex() *int {
+func (c *Core) GetLastConsensusRoundIndex() *int64 {
 	return c.poset.LastConsensusRound
 }
 
@@ -559,6 +559,6 @@ func (c *Core) GetLastCommittedRoundEventsCount() int {
 	return c.poset.LastCommitedRoundEvents
 }
 
-func (c *Core) GetLastBlockIndex() int {
+func (c *Core) GetLastBlockIndex() int64 {
 	return c.poset.Store.LastBlockIndex()
 }

--- a/src/node/core_test.go
+++ b/src/node/core_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/andrecronje/lachesis/src/poset"
 )
 
-func initCores(n int, t *testing.T) ([]Core, map[int]*ecdsa.PrivateKey, map[string]string) {
+func initCores(n int, t *testing.T) ([]Core, map[int64]*ecdsa.PrivateKey, map[string]string) {
 	cacheSize := 1000
 
 	var cores []Core
 	index := make(map[string]string)
-	participantKeys := map[int]*ecdsa.PrivateKey{}
+	participantKeys := map[int64]*ecdsa.PrivateKey{}
 
 	// participantKeys := []*ecdsa.PrivateKey{}
 	participants := peers.NewPeers()
@@ -31,7 +31,7 @@ func initCores(n int, t *testing.T) ([]Core, map[int]*ecdsa.PrivateKey, map[stri
 	}
 
 	for i, peer := range participants.ToPeerSlice() {
-		core := NewCore(i,
+		core := NewCore(int64(i),
 			participantKeys[peer.ID],
 			participants,
 			poset.NewInmemStore(participants, cacheSize),
@@ -40,7 +40,7 @@ func initCores(n int, t *testing.T) ([]Core, map[int]*ecdsa.PrivateKey, map[stri
 
 		selfParent := fmt.Sprintf("Root%d", peer.ID)
 
-		flagTable := make(map[string]int)
+		flagTable := make(map[string]int64)
 		flagTable[selfParent] = 1
 
 		// Create and save the first Event
@@ -70,9 +70,9 @@ e01 |   |
 e0  e1  e2
 0   1   2
 */
-func initPoset(t *testing.T, cores []Core, keys map[int]*ecdsa.PrivateKey,
-	index map[string]string, participant int) {
-	for i := 0; i < len(cores); i++ {
+func initPoset(t *testing.T, cores []Core, keys map[int64]*ecdsa.PrivateKey,
+	index map[string]string, participant int64) {
+	for i := int64(0); i < int64(len(cores)); i++ {
 		if i != participant {
 			event, err := cores[i].GetEvent(index[fmt.Sprintf("e%d", i)])
 			if err != nil {
@@ -97,13 +97,13 @@ func initPoset(t *testing.T, cores []Core, keys map[int]*ecdsa.PrivateKey,
 	}
 
 	event1ft, _ := event1.GetFlagTable()
-	event01ft, _ := event0.MargeFlagTable(event1ft)
+	event01ft, _ := event0.MergeFlagTable(event1ft)
 
 	event01 := poset.NewEvent([][]byte{}, nil,
 		[]string{index["e0"], index["e1"]}, // e0 and e1
 		cores[0].PubKey(), 1, event01ft)
 	if err := insertEvent(cores, keys, index, event01, "e01", participant,
-		common.Hash32(cores[0].pubKey)); err != nil {
+		int64(common.Hash32(cores[0].pubKey))); err != nil {
 		t.Fatalf("error inserting e01: %s\n", err)
 	}
 
@@ -113,29 +113,29 @@ func initPoset(t *testing.T, cores []Core, keys map[int]*ecdsa.PrivateKey,
 		t.Fatalf("failed to get parent: %s", err)
 	}
 
-	event20ft, _ := event2.MargeFlagTable(event01ft)
+	event20ft, _ := event2.MergeFlagTable(event01ft)
 
 	event20 := poset.NewEvent([][]byte{}, nil,
 		[]string{index["e2"], index["e01"]}, // e2 and e01
 		cores[2].PubKey(), 1, event20ft)
 	if err := insertEvent(cores, keys, index, event20, "e20", participant,
-		common.Hash32(cores[2].pubKey)); err != nil {
+		int64(common.Hash32(cores[2].pubKey))); err != nil {
 		fmt.Printf("error inserting e20: %s\n", err)
 	}
 
-	event12ft, _ := event1.MargeFlagTable(event20ft)
+	event12ft, _ := event1.MergeFlagTable(event20ft)
 
 	event12 := poset.NewEvent([][]byte{}, nil,
 		[]string{index["e1"], index["e20"]}, // e1 and e20
 		cores[1].PubKey(), 1, event12ft)
 	if err := insertEvent(cores, keys, index, event12, "e12", participant,
-		common.Hash32(cores[1].pubKey)); err != nil {
+		int64(common.Hash32(cores[1].pubKey))); err != nil {
 		fmt.Printf("error inserting e12: %s\n", err)
 	}
 }
 
-func insertEvent(cores []Core, keys map[int]*ecdsa.PrivateKey, index map[string]string,
-	event poset.Event, name string, participant int, creator int) error {
+func insertEvent(cores []Core, keys map[int64]*ecdsa.PrivateKey, index map[string]string,
+	event poset.Event, name string, participant int64, creator int64) error {
 
 	if participant == creator {
 		if err := cores[participant].SignAndInsertSelfEvent(event); err != nil {
@@ -261,13 +261,13 @@ func TestSync(t *testing.T) {
 	checkHeights(cores, expectedHeights, t)
 
 	knownBy0 := cores[0].KnownEvents()
-	if k := knownBy0[common.Hash32(cores[0].pubKey)]; k != 1 {
+	if k := knownBy0[int64(common.Hash32(cores[0].pubKey))]; k != 1 {
 		t.Fatalf("core 0 should have last-index 1 for core 0, not %d", k)
 	}
-	if k := knownBy0[common.Hash32(cores[1].pubKey)]; k != 0 {
+	if k := knownBy0[int64(common.Hash32(cores[1].pubKey))]; k != 0 {
 		t.Fatalf("core 0 should have last-index 0 for core 1, not %d", k)
 	}
-	if k := knownBy0[common.Hash32(cores[2].pubKey)]; k != -1 {
+	if k := knownBy0[int64(common.Hash32(cores[2].pubKey))]; k != -1 {
 		t.Fatalf("core 0 should have last-index -1 for core 2, not %d", k)
 	}
 	core0Head, _ := cores[0].GetHead()
@@ -319,13 +319,13 @@ func TestSync(t *testing.T) {
 	checkHeights(cores, expectedHeights, t)
 
 	knownBy2 := cores[2].KnownEvents()
-	if k := knownBy2[common.Hash32(cores[0].pubKey)]; k != 1 {
+	if k := knownBy2[int64(common.Hash32(cores[0].pubKey))]; k != 1 {
 		t.Fatalf("core 2 should have last-index 1 for core 0, not %d", k)
 	}
-	if k := knownBy2[common.Hash32(cores[1].pubKey)]; k != 0 {
+	if k := knownBy2[int64(common.Hash32(cores[1].pubKey))]; k != 0 {
 		t.Fatalf("core 2 should have last-index 0 core 1, not %d", k)
 	}
-	if k := knownBy2[common.Hash32(cores[2].pubKey)]; k != 1 {
+	if k := knownBy2[int64(common.Hash32(cores[2].pubKey))]; k != 1 {
 		t.Fatalf("core 2 should have last-index 1 for core 2, not %d", k)
 	}
 	core2Head, _ := cores[2].GetHead()
@@ -375,13 +375,13 @@ func TestSync(t *testing.T) {
 	checkHeights(cores, expectedHeights, t)
 
 	knownBy1 := cores[1].KnownEvents()
-	if k := knownBy1[common.Hash32(cores[0].pubKey)]; k != 1 {
+	if k := knownBy1[int64(common.Hash32(cores[0].pubKey))]; k != 1 {
 		t.Fatalf("core 1 should have last-index 1 for core 0, not %d", k)
 	}
-	if k := knownBy1[common.Hash32(cores[1].pubKey)]; k != 1 {
+	if k := knownBy1[int64(common.Hash32(cores[1].pubKey))]; k != 1 {
 		t.Fatalf("core 1 should have last-index 1 for core 1, not %d", k)
 	}
-	if k := knownBy1[common.Hash32(cores[2].pubKey)]; k != 1 {
+	if k := knownBy1[int64(common.Hash32(cores[2].pubKey))]; k != 1 {
 		t.Fatalf("core 1 should have last-index 1 for core 2, not %d", k)
 	}
 	core1Head, _ := cores[1].GetHead()
@@ -726,23 +726,23 @@ func TestOverSyncLimit(t *testing.T) {
 	cores := initConsensusPoset(t)
 
 	// positive
-	known := map[int]int{
-		common.Hash32(cores[0].pubKey): 1,
-		common.Hash32(cores[1].pubKey): 1,
-		common.Hash32(cores[2].pubKey): 1,
+	known := map[int64]int64{
+		int64(common.Hash32(cores[0].pubKey)): 1,
+		int64(common.Hash32(cores[1].pubKey)): 1,
+		int64(common.Hash32(cores[2].pubKey)): 1,
 	}
 
-	syncLimit := 10
+	syncLimit := int64(10)
 
 	if !cores[0].OverSyncLimit(known, syncLimit) {
 		t.Fatalf("OverSyncLimit(%v, %v) should return true", known, syncLimit)
 	}
 
 	// negative
-	known = map[int]int{
-		common.Hash32(cores[0].pubKey): 6,
-		common.Hash32(cores[1].pubKey): 6,
-		common.Hash32(cores[2].pubKey): 6,
+	known = map[int64]int64{
+		int64(common.Hash32(cores[0].pubKey)): 6,
+		int64(common.Hash32(cores[1].pubKey)): 6,
+		int64(common.Hash32(cores[2].pubKey)): 6,
 	}
 
 	if cores[0].OverSyncLimit(known, syncLimit) {
@@ -750,10 +750,10 @@ func TestOverSyncLimit(t *testing.T) {
 	}
 
 	// edge
-	known = map[int]int{
-		common.Hash32(cores[0].pubKey): 2,
-		common.Hash32(cores[1].pubKey): 3,
-		common.Hash32(cores[2].pubKey): 3,
+	known = map[int64]int64{
+		int64(common.Hash32(cores[0].pubKey)): 2,
+		int64(common.Hash32(cores[1].pubKey)): 3,
+		int64(common.Hash32(cores[2].pubKey)): 3,
 	}
 	if cores[0].OverSyncLimit(known, syncLimit) {
 		t.Fatalf("OverSyncLimit(%v, %v) should return false", known, syncLimit)
@@ -830,7 +830,7 @@ func TestConsensusFF(t *testing.T) {
 	if r := cores[1].GetLastConsensusRoundIndex(); r == nil || *r != 1 {
 		disp := "nil"
 		if r != nil {
-			disp = strconv.Itoa(*r)
+			disp = strconv.FormatInt(*r, 10)
 		}
 		t.Fatalf("Cores[1] last consensus Round should be 1, not %s", disp)
 	}
@@ -895,7 +895,7 @@ func TestCoreFastForward(t *testing.T) {
 			t.Fatal(err)
 		}
 		// Assign AnchorBlock
-		cores[1].poset.AnchorBlock = new(int)
+		cores[1].poset.AnchorBlock = new(int64)
 		*cores[1].poset.AnchorBlock = 0
 
 		// Now the function should find an AnchorBlock
@@ -940,11 +940,11 @@ func TestCoreFastForward(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		expectedKnown := map[int]int{
-			common.Hash32(cores[0].pubKey): -1,
-			common.Hash32(cores[1].pubKey): 1,
-			common.Hash32(cores[2].pubKey): 1,
-			common.Hash32(cores[3].pubKey): 1,
+		expectedKnown := map[int64]int64{
+			int64(common.Hash32(cores[0].pubKey)): -1,
+			int64(common.Hash32(cores[1].pubKey)): 1,
+			int64(common.Hash32(cores[2].pubKey)): 1,
+			int64(common.Hash32(cores[3].pubKey)): 1,
 		}
 
 		if !reflect.DeepEqual(knownBy0, expectedKnown) {

--- a/src/node/graph.go
+++ b/src/node/graph.go
@@ -18,7 +18,7 @@ type Graph struct {
 
 func (g *Graph) GetBlocks() []poset.Block {
 	res := []poset.Block{}
- 	blockIdx := 0
+ 	blockIdx := int64(0)
 	store := g.Node.core.poset.Store
 
  	for blockIdx <= store.LastBlockIndex() {
@@ -55,7 +55,7 @@ func (g *Graph) GetParticipantEvents() map[string]map[string]poset.Event {
 
 		selfParent := fmt.Sprintf("Root%d", p.ID)
 
-		flagTable := make(map[string]int)
+		flagTable := make(map[string]int64)
 		flagTable[selfParent] = 1
 
 		// Create and save the first Event
@@ -83,7 +83,7 @@ func (g *Graph) GetParticipantEvents() map[string]map[string]poset.Event {
 func (g *Graph) GetRounds() []poset.RoundInfo {
 	res := []poset.RoundInfo{}
 
-	round := 0
+	round := int64(0)
 
 	store := g.Node.core.poset.Store
 

--- a/src/peers/peer.go
+++ b/src/peers/peer.go
@@ -11,7 +11,7 @@ const (
 )
 
 type Peer struct {
-	ID        int `json:"-"`
+	ID        int64 `json:"-"`
 	NetAddr   string
 	PubKeyHex string
 }
@@ -39,7 +39,7 @@ func (p *Peer) computeID() error {
 		return err
 	}
 
-	p.ID = common.Hash32(pubKey)
+	p.ID = int64(common.Hash32(pubKey))
 
 	return nil
 }

--- a/src/peers/peers.go
+++ b/src/peers/peers.go
@@ -6,7 +6,7 @@ import (
 )
 
 type PubKeyPeers map[string]*Peer
-type IdPeers map[int]*Peer
+type IdPeers map[int64]*Peer
 
 type Peers struct {
 	sync.RWMutex
@@ -92,7 +92,7 @@ func (p *Peers) RemovePeerByPubKey(pubKey string) {
 	p.RemovePeer(p.ByPubKey[pubKey])
 }
 
-func (p *Peers) RemovePeerById(id int) {
+func (p *Peers) RemovePeerById(id int64) {
 	p.RemovePeer(p.ById[id])
 }
 
@@ -115,11 +115,11 @@ func (p *Peers) ToPubKeySlice() []string {
 	return res
 }
 
-func (p *Peers) ToIDSlice() []int {
+func (p *Peers) ToIDSlice() []int64 {
 	p.RLock()
 	defer p.RUnlock()
 
-	res := []int{}
+	res := []int64{}
 
 	for _, peer := range p.Sorted {
 		res = append(res, peer.ID)

--- a/src/poset/badger_store_test.go
+++ b/src/poset/badger_store_test.go
@@ -150,17 +150,17 @@ func TestLoadBadgerStore(t *testing.T) {
 
 func TestDBEventMethods(t *testing.T) {
 	cacheSize := 0
-	testSize := 100
+	testSize := int64(100)
 	store, participants := initBadgerStore(cacheSize, t)
 	defer removeBadgerStore(store, t)
 
 	//insert events in db directly
 	events := make(map[string][]Event)
-	topologicalIndex := 0
+	topologicalIndex := int64(0)
 	var topologicalEvents []Event
 	for _, p := range participants {
 		var items []Event
-		for k := 0; k < testSize; k++ {
+		for k := int64(0); k < testSize; k++ {
 			event := NewEvent(
 				[][]byte{[]byte(fmt.Sprintf("%s_%d", p.hex[:5], k))},
 				[]BlockSignature{{Validator: []byte("validator"), Index: 0, Signature: "r|s"}},
@@ -234,13 +234,13 @@ func TestDBEventMethods(t *testing.T) {
 	}
 
 	//check that participant events where correctly added
-	skipIndex := -1 //do not skip any indexes
+	skipIndex := int64(-1) //do not skip any indexes
 	for _, p := range participants {
 		pEvents, err := store.dbParticipantEvents(p.hex, skipIndex)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if l := len(pEvents); l != testSize {
+		if l := int64(len(pEvents)); l != testSize {
 			t.Fatalf("%s should have %d events, not %d", p.hex, testSize, l)
 		}
 
@@ -326,8 +326,8 @@ func TestDBBlockMethods(t *testing.T) {
 	store, participants := initBadgerStore(cacheSize, t)
 	defer removeBadgerStore(store, t)
 
-	index := 0
-	roundReceived := 5
+	index := int64(0)
+	roundReceived := int64(5)
 	transactions := [][]byte{
 		[]byte("tx1"),
 		[]byte("tx2"),
@@ -408,7 +408,7 @@ func TestDBFrameMethods(t *testing.T) {
 		event.Sign(p.privKey)
 		events = append(events, event)
 
-		root := NewBaseRoot(id)
+		root := NewBaseRoot(int64(id))
 		roots = append(roots, root)
 	}
 	frame := Frame{
@@ -440,7 +440,7 @@ func TestDBFrameMethods(t *testing.T) {
 func TestBadgerEvents(t *testing.T) {
 	//Insert more events than can fit in cache to test retrieving from db.
 	cacheSize := 10
-	testSize := 100
+	testSize := int64(100)
 	store, participants := initBadgerStore(cacheSize, t)
 	defer removeBadgerStore(store, t)
 
@@ -448,7 +448,7 @@ func TestBadgerEvents(t *testing.T) {
 	events := make(map[string][]Event)
 	for _, p := range participants {
 		var items []Event
-		for k := 0; k < testSize; k++ {
+		for k := int64(0); k < testSize; k++ {
 			event := NewEvent([][]byte{[]byte(fmt.Sprintf("%s_%d", p.hex[:5], k))},
 				[]BlockSignature{{Validator: []byte("validator"), Index: 0, Signature: "r|s"}},
 				[]string{"", ""},
@@ -480,13 +480,13 @@ func TestBadgerEvents(t *testing.T) {
 	}
 
 	//check retrieving events per participant
-	skipIndex := -1 //do not skip any indexes
+	skipIndex := int64(-1) //do not skip any indexes
 	for _, p := range participants {
 		pEvents, err := store.ParticipantEvents(p.hex, skipIndex)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if l := len(pEvents); l != testSize {
+		if l := int64(len(pEvents)); l != testSize {
 			t.Fatalf("%s should have %d events, not %d", p.hex, testSize, l)
 		}
 
@@ -513,7 +513,7 @@ func TestBadgerEvents(t *testing.T) {
 		}
 	}
 
-	expectedKnown := make(map[int]int)
+	expectedKnown := make(map[int64]int64)
 	for _, p := range participants {
 		expectedKnown[p.id] = testSize - 1
 	}
@@ -584,8 +584,8 @@ func TestBadgerBlocks(t *testing.T) {
 	store, participants := initBadgerStore(cacheSize, t)
 	defer removeBadgerStore(store, t)
 
-	index := 0
-	roundReceived := 5
+	index := int64(0)
+	roundReceived := int64(5)
 	transactions := [][]byte{
 		[]byte("tx1"),
 		[]byte("tx2"),
@@ -665,7 +665,7 @@ func TestBadgerFrames(t *testing.T) {
 		event.Sign(p.privKey)
 		events = append(events, event)
 
-		root := NewBaseRoot(id)
+		root := NewBaseRoot(int64(id))
 		roots = append(roots, root)
 	}
 	frame := Frame{

--- a/src/poset/block.go
+++ b/src/poset/block.go
@@ -16,8 +16,8 @@ import (
 //statehash should be ignored for validator checking
 
 type BlockBody struct {
-	Index         int
-	RoundReceived int
+	Index         int64
+	RoundReceived int64
 	StateHash     []byte
 	FrameHash     []byte
 	Transactions  [][]byte
@@ -54,7 +54,7 @@ func (bb *BlockBody) Hash() ([]byte, error) {
 
 type BlockSignature struct {
 	Validator []byte
-	Index     int
+	Index     int64
 	Signature string
 }
 
@@ -88,7 +88,7 @@ func (bs *BlockSignature) ToWire() WireBlockSignature {
 }
 
 type WireBlockSignature struct {
-	Index     int
+	Index     int64
 	Signature string
 }
 
@@ -102,7 +102,7 @@ type Block struct {
 	hex  string
 }
 
-func NewBlockFromFrame(blockIndex int, frame Frame) (Block, error) {
+func NewBlockFromFrame(blockIndex int64, frame Frame) (Block, error) {
 	frameHash, err := frame.Hash()
 	if err != nil {
 		return Block{}, err
@@ -114,7 +114,7 @@ func NewBlockFromFrame(blockIndex int, frame Frame) (Block, error) {
 	return NewBlock(blockIndex, frame.Round, frameHash, transactions), nil
 }
 
-func NewBlock(blockIndex, roundReceived int, frameHash []byte, txs [][]byte) Block {
+func NewBlock(blockIndex, roundReceived int64, frameHash []byte, txs [][]byte) Block {
 	body := BlockBody{
 		Index:         blockIndex,
 		RoundReceived: roundReceived,
@@ -127,7 +127,7 @@ func NewBlock(blockIndex, roundReceived int, frameHash []byte, txs [][]byte) Blo
 	}
 }
 
-func (b *Block) Index() int {
+func (b *Block) Index() int64 {
 	return b.Body.Index
 }
 
@@ -135,7 +135,7 @@ func (b *Block) Transactions() [][]byte {
 	return b.Body.Transactions
 }
 
-func (b *Block) RoundReceived() int {
+func (b *Block) RoundReceived() int64 {
 	return b.Body.RoundReceived
 }
 

--- a/src/poset/caches.go
+++ b/src/poset/caches.go
@@ -43,7 +43,7 @@ func NewParticipantEventsCache(size int, participants *peers.Peers) *Participant
 	}
 }
 
-func (pec *ParticipantEventsCache) participantID(participant string) (int, error) {
+func (pec *ParticipantEventsCache) participantID(participant string) (int64, error) {
 	peer, ok := pec.participants.ByPubKey[participant]
 
 	if !ok {
@@ -54,7 +54,7 @@ func (pec *ParticipantEventsCache) participantID(participant string) (int, error
 }
 
 //return participant events with index > skip
-func (pec *ParticipantEventsCache) Get(participant string, skipIndex int) ([]string, error) {
+func (pec *ParticipantEventsCache) Get(participant string, skipIndex int64) ([]string, error) {
 	id, err := pec.participantID(participant)
 	if err != nil {
 		return []string{}, err
@@ -72,7 +72,7 @@ func (pec *ParticipantEventsCache) Get(participant string, skipIndex int) ([]str
 	return res, nil
 }
 
-func (pec *ParticipantEventsCache) GetItem(participant string, index int) (string, error) {
+func (pec *ParticipantEventsCache) GetItem(participant string, index int64) (string, error) {
 	id, err := pec.participantID(participant)
 	if err != nil {
 		return "", err
@@ -111,7 +111,7 @@ func (pec *ParticipantEventsCache) GetLastConsensus(participant string) (string,
 	return last.(string), nil
 }
 
-func (pec *ParticipantEventsCache) Set(participant string, hash string, index int) error {
+func (pec *ParticipantEventsCache) Set(participant string, hash string, index int64) error {
 	id, err := pec.participantID(participant)
 	if err != nil {
 		return err
@@ -120,7 +120,7 @@ func (pec *ParticipantEventsCache) Set(participant string, hash string, index in
 }
 
 //returns [participant id] => lastKnownIndex
-func (pec *ParticipantEventsCache) Known() map[int]int {
+func (pec *ParticipantEventsCache) Known() map[int64]int64 {
 	return pec.rim.Known()
 }
 
@@ -142,7 +142,7 @@ func NewParticipantBlockSignaturesCache(size int, participants *peers.Peers) *Pa
 	}
 }
 
-func (psc *ParticipantBlockSignaturesCache) participantID(participant string) (int, error) {
+func (psc *ParticipantBlockSignaturesCache) participantID(participant string) (int64, error) {
 	peer, ok := psc.participants.ByPubKey[participant]
 
 	if !ok {
@@ -153,7 +153,7 @@ func (psc *ParticipantBlockSignaturesCache) participantID(participant string) (i
 }
 
 //return participant BlockSignatures where index > skip
-func (psc *ParticipantBlockSignaturesCache) Get(participant string, skipIndex int) ([]BlockSignature, error) {
+func (psc *ParticipantBlockSignaturesCache) Get(participant string, skipIndex int64) ([]BlockSignature, error) {
 	id, err := psc.participantID(participant)
 	if err != nil {
 		return []BlockSignature{}, err
@@ -171,7 +171,7 @@ func (psc *ParticipantBlockSignaturesCache) Get(participant string, skipIndex in
 	return res, nil
 }
 
-func (psc *ParticipantBlockSignaturesCache) GetItem(participant string, index int) (BlockSignature, error) {
+func (psc *ParticipantBlockSignaturesCache) GetItem(participant string, index int64) (BlockSignature, error) {
 	id, err := psc.participantID(participant)
 	if err != nil {
 		return BlockSignature{}, err
@@ -204,7 +204,7 @@ func (psc *ParticipantBlockSignaturesCache) Set(participant string, sig BlockSig
 }
 
 //returns [participant id] => last BlockSignature Index
-func (psc *ParticipantBlockSignaturesCache) Known() map[int]int {
+func (psc *ParticipantBlockSignaturesCache) Known() map[int64]int64 {
 	return psc.rim.Known()
 }
 

--- a/src/poset/caches_test.go
+++ b/src/poset/caches_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestParticipantEventsCache(t *testing.T) {
 	size := 10
-	testSize := 25
+	testSize := int64(25)
 	participants := peers.NewPeersFromSlice([]*peers.Peer{
 		peers.NewPeer("0xaa", ""),
 		peers.NewPeer("0xbb", ""),
@@ -25,7 +25,7 @@ func TestParticipantEventsCache(t *testing.T) {
 		items[pk] = []string{}
 	}
 
-	for i := 0; i < testSize; i++ {
+	for i := int64(0); i < testSize; i++ {
 		for pk := range participants.ByPubKey {
 			item := fmt.Sprintf("%s%d", pk, i)
 
@@ -40,13 +40,13 @@ func TestParticipantEventsCache(t *testing.T) {
 	// GET ITEM ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 	for pk := range participants.ByPubKey {
 
-		index1 := 9
+		index1 := int64(9)
 		_, err := pec.GetItem(pk, index1)
 		if err == nil || !cm.Is(err, cm.TooLate) {
 			t.Fatalf("Expected ErrTooLate")
 		}
 
-		index2 := 15
+		index2 := int64(15)
 		expected2 := items[pk][index2]
 		actual2, err := pec.GetItem(pk, index2)
 		if err != nil {
@@ -56,7 +56,7 @@ func TestParticipantEventsCache(t *testing.T) {
 			t.Fatalf("expected and cached not equal")
 		}
 
-		index3 := 27
+		index3 := int64(27)
 		actual3, err := pec.Get(pk, index3)
 		if err != nil {
 			t.Fatal(err)
@@ -82,7 +82,7 @@ func TestParticipantEventsCache(t *testing.T) {
 			t.Fatalf("Skipping 0 elements should return ErrTooLate")
 		}
 
-		skipIndex := 9
+		skipIndex := int64(9)
 		expected := items[pk][skipIndex+1:]
 		cached, err := pec.Get(pk, skipIndex)
 		if err != nil {
@@ -92,7 +92,7 @@ func TestParticipantEventsCache(t *testing.T) {
 			t.Fatalf("expected and cached not equal")
 		}
 
-		skipIndex2 := 15
+		skipIndex2 := int64(15)
 		expected2 := items[pk][skipIndex2+1:]
 		cached2, err := pec.Get(pk, skipIndex2)
 		if err != nil {
@@ -102,7 +102,7 @@ func TestParticipantEventsCache(t *testing.T) {
 			t.Fatalf("expected and cached not equal")
 		}
 
-		skipIndex3 := 27
+		skipIndex3 := int64(27)
 		cached3, err := pec.Get(pk, skipIndex3)
 		if err != nil {
 			t.Fatal(err)
@@ -115,7 +115,7 @@ func TestParticipantEventsCache(t *testing.T) {
 
 func TestParticipantEventsCacheEdge(t *testing.T) {
 	size := 10
-	testSize := 11
+	testSize := int64(11)
 	participants := peers.NewPeersFromSlice([]*peers.Peer{
 		peers.NewPeer("0xaa", ""),
 		peers.NewPeer("0xbb", ""),
@@ -129,7 +129,7 @@ func TestParticipantEventsCacheEdge(t *testing.T) {
 		items[pk] = []string{}
 	}
 
-	for i := 0; i < testSize; i++ {
+	for i := int64(0); i < testSize; i++ {
 		for pk := range participants.ByPubKey {
 			item := fmt.Sprintf("%s%d", pk, i)
 
@@ -143,7 +143,7 @@ func TestParticipantEventsCacheEdge(t *testing.T) {
 
 	for pk := range participants.ByPubKey {
 		expected := items[pk][size:]
-		cached, err := pec.Get(pk, size-1)
+		cached, err := pec.Get(pk, int64(size-1))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/src/poset/event_test.go
+++ b/src/poset/event_test.go
@@ -172,7 +172,7 @@ func TestIsLoaded(t *testing.T) {
 }
 
 func TestEventFlagTable(t *testing.T) {
-	exp := map[string]int{
+	exp := map[string]int64{
 		"x": 1,
 		"y": 0,
 		"z": 2,
@@ -197,14 +197,14 @@ func TestEventFlagTable(t *testing.T) {
 	}
 }
 
-func TestMargeFlagTable(t *testing.T) {
-	exp := map[string]int{
+func TestMergeFlagTable(t *testing.T) {
+	exp := map[string]int64{
 		"x": 1,
 		"y": 1,
 		"z": 1,
 	}
 
-	syncData := []map[string]int{
+	syncData := []map[string]int64{
 		{
 			"x": 0,
 			"y": 1,
@@ -217,7 +217,7 @@ func TestMargeFlagTable(t *testing.T) {
 		},
 	}
 
-	start := map[string]int{
+	start := map[string]int64{
 		"x": 1,
 		"y": 0,
 		"z": 0,
@@ -227,7 +227,7 @@ func TestMargeFlagTable(t *testing.T) {
 	event := Event{FlagTable: ft}
 
 	for _, v := range syncData {
-		flagTable, err := event.MargeFlagTable(v)
+		flagTable, err := event.MergeFlagTable(v)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -236,7 +236,7 @@ func TestMargeFlagTable(t *testing.T) {
 		event.FlagTable = raw
 	}
 
-	var res map[string]int
+	var res map[string]int64
 	json.Unmarshal(event.FlagTable, &res)
 
 	if !reflect.DeepEqual(exp, res) {

--- a/src/poset/frame.go
+++ b/src/poset/frame.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Frame struct {
-	Round  int     //RoundReceived
+	Round  int64     //RoundReceived
 	Roots  []Root  // [participant ID] => Root
 	Events []Event //Event with RoundReceived = Round
 }

--- a/src/poset/inmem_store.go
+++ b/src/poset/inmem_store.go
@@ -16,13 +16,13 @@ type InmemStore struct {
 	blockCache             *cm.LRU
 	frameCache             *cm.LRU
 	consensusCache         *cm.RollingIndex
-	totConsensusEvents     int
+	totConsensusEvents     int64
 	participantEventsCache *ParticipantEventsCache
 	rootsByParticipant     map[string]Root //[participant] => Root
 	rootsBySelfParent      map[string]Root //[Root.SelfParent.Hash] => Root
-	lastRound              int
+	lastRound              int64
 	lastConsensusEvents    map[string]string //[participant] => hex() of last consensus event
-	lastBlock              int
+	lastBlock              int64
 }
 
 func NewInmemStore(participants *peers.Peers, cacheSize int) *InmemStore {
@@ -94,15 +94,15 @@ func (s *InmemStore) SetEvent(event Event) error {
 	return nil
 }
 
-func (s *InmemStore) addParticpantEvent(participant string, hash string, index int) error {
+func (s *InmemStore) addParticpantEvent(participant string, hash string, index int64) error {
 	return s.participantEventsCache.Set(participant, hash, index)
 }
 
-func (s *InmemStore) ParticipantEvents(participant string, skip int) ([]string, error) {
+func (s *InmemStore) ParticipantEvents(participant string, skip int64) ([]string, error) {
 	return s.participantEventsCache.Get(participant, skip)
 }
 
-func (s *InmemStore) ParticipantEvent(participant string, index int) (string, error) {
+func (s *InmemStore) ParticipantEvent(participant string, index int64) (string, error) {
 	ev, err := s.participantEventsCache.GetItem(participant, index)
 	if err != nil {
 		root, ok := s.rootsByParticipant[participant]
@@ -151,7 +151,7 @@ func (s *InmemStore) LastConsensusEventFrom(participant string) (last string, is
 	return
 }
 
-func (s *InmemStore) KnownEvents() map[int]int {
+func (s *InmemStore) KnownEvents() map[int64]int64 {
 	known := s.participantEventsCache.Known()
 	for p, pid := range s.participants.ByPubKey {
 		if known[pid.ID] == -1 {
@@ -173,7 +173,7 @@ func (s *InmemStore) ConsensusEvents() []string {
 	return res
 }
 
-func (s *InmemStore) ConsensusEventsCount() int {
+func (s *InmemStore) ConsensusEventsCount() int64 {
 	return s.totConsensusEvents
 }
 
@@ -184,15 +184,15 @@ func (s *InmemStore) AddConsensusEvent(event Event) error {
 	return nil
 }
 
-func (s *InmemStore) GetRound(r int) (RoundInfo, error) {
+func (s *InmemStore) GetRound(r int64) (RoundInfo, error) {
 	res, ok := s.roundCache.Get(r)
 	if !ok {
-		return *NewRoundInfo(), cm.NewStoreErr("RoundCache", cm.KeyNotFound, strconv.Itoa(r))
+		return *NewRoundInfo(), cm.NewStoreErr("RoundCache", cm.KeyNotFound, strconv.FormatInt(r, 10))
 	}
 	return res.(RoundInfo), nil
 }
 
-func (s *InmemStore) SetRound(r int, round RoundInfo) error {
+func (s *InmemStore) SetRound(r int64, round RoundInfo) error {
 	s.roundCache.Add(r, round)
 	if r > s.lastRound {
 		s.lastRound = r
@@ -200,11 +200,11 @@ func (s *InmemStore) SetRound(r int, round RoundInfo) error {
 	return nil
 }
 
-func (s *InmemStore) LastRound() int {
+func (s *InmemStore) LastRound() int64 {
 	return s.lastRound
 }
 
-func (s *InmemStore) RoundWitnesses(r int) []string {
+func (s *InmemStore) RoundWitnesses(r int64) []string {
 	round, err := s.GetRound(r)
 	if err != nil {
 		return []string{}
@@ -212,7 +212,7 @@ func (s *InmemStore) RoundWitnesses(r int) []string {
 	return round.Witnesses()
 }
 
-func (s *InmemStore) RoundEvents(r int) int {
+func (s *InmemStore) RoundEvents(r int64) int {
 	round, err := s.GetRound(r)
 	if err != nil {
 		return 0
@@ -228,10 +228,10 @@ func (s *InmemStore) GetRoot(participant string) (Root, error) {
 	return res, nil
 }
 
-func (s *InmemStore) GetBlock(index int) (Block, error) {
+func (s *InmemStore) GetBlock(index int64) (Block, error) {
 	res, ok := s.blockCache.Get(index)
 	if !ok {
-		return Block{}, cm.NewStoreErr("BlockCache", cm.KeyNotFound, strconv.Itoa(index))
+		return Block{}, cm.NewStoreErr("BlockCache", cm.KeyNotFound, strconv.FormatInt(index, 10))
 	}
 	return res.(Block), nil
 }
@@ -249,14 +249,14 @@ func (s *InmemStore) SetBlock(block Block) error {
 	return nil
 }
 
-func (s *InmemStore) LastBlockIndex() int {
+func (s *InmemStore) LastBlockIndex() int64 {
 	return s.lastBlock
 }
 
-func (s *InmemStore) GetFrame(index int) (Frame, error) {
+func (s *InmemStore) GetFrame(index int64) (Frame, error) {
 	res, ok := s.frameCache.Get(index)
 	if !ok {
-		return Frame{}, cm.NewStoreErr("FrameCache", cm.KeyNotFound, strconv.Itoa(index))
+		return Frame{}, cm.NewStoreErr("FrameCache", cm.KeyNotFound, strconv.FormatInt(index, 10))
 	}
 	return res.(Frame), nil
 }

--- a/src/poset/inmem_store_test.go
+++ b/src/poset/inmem_store_test.go
@@ -11,17 +11,17 @@ import (
 )
 
 type pub struct {
-	id      int
+	id      int64
 	privKey *ecdsa.PrivateKey
 	pubKey  []byte
 	hex     string
 }
 
 func initInmemStore(cacheSize int) (*InmemStore, []pub) {
-	n := 3
+	n := int64(3)
 	var participantPubs []pub
 	participants := peers.NewPeers()
-	for i := 0; i < n; i++ {
+	for i := int64(0); i < n; i++ {
 		key, _ := crypto.GenerateECDSAKey()
 		pubKey := crypto.FromECDSAPub(&key.PublicKey)
 		peer := peers.NewPeer(fmt.Sprintf("0x%X", pubKey), "")
@@ -37,7 +37,7 @@ func initInmemStore(cacheSize int) (*InmemStore, []pub) {
 
 func TestInmemEvents(t *testing.T) {
 	cacheSize := 100
-	testSize := 15
+	testSize := int64(15)
 	store, participants := initInmemStore(cacheSize)
 
 	events := make(map[string][]Event)
@@ -45,7 +45,7 @@ func TestInmemEvents(t *testing.T) {
 	t.Run("Store Events", func(t *testing.T) {
 		for _, p := range participants {
 			var items []Event
-			for k := 0; k < testSize; k++ {
+			for k := int64(0); k < testSize; k++ {
 				event := NewEvent([][]byte{[]byte(fmt.Sprintf("%s_%d", p.hex[:5], k))},
 					[]BlockSignature{{Validator: []byte("validator"), Index: 0, Signature: "r|s"}},
 					[]string{"", ""},
@@ -75,13 +75,13 @@ func TestInmemEvents(t *testing.T) {
 	})
 
 	t.Run("Check ParticipantEventsCache", func(t *testing.T) {
-		skipIndex := -1 //do not skip any indexes
+		skipIndex := int64(-1) //do not skip any indexes
 		for _, p := range participants {
 			pEvents, err := store.ParticipantEvents(p.hex, skipIndex)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if l := len(pEvents); l != testSize {
+			if l := int64(len(pEvents)); l != testSize {
 				t.Fatalf("%s should have %d Events, not %d", p.hex, testSize, l)
 			}
 
@@ -96,7 +96,7 @@ func TestInmemEvents(t *testing.T) {
 	})
 
 	t.Run("Check KnownEvents", func(t *testing.T) {
-		expectedKnown := make(map[int]int)
+		expectedKnown := make(map[int64]int64)
 		for _, p := range participants {
 			expectedKnown[p.id] = testSize - 1
 		}
@@ -171,8 +171,8 @@ func TestInmemRounds(t *testing.T) {
 func TestInmemBlocks(t *testing.T) {
 	store, participants := initInmemStore(10)
 
-	index := 0
-	roundReceived := 7
+	index := int64(0)
+	roundReceived := int64(7)
 	transactions := [][]byte{
 		[]byte("tx1"),
 		[]byte("tx2"),

--- a/src/poset/poset_test.go
+++ b/src/poset/poset_test.go
@@ -62,12 +62,12 @@ type ancestryItem struct {
 
 type roundItem struct {
 	event string
-	round int
+	round int64
 }
 
 type play struct {
 	to          int
-	index       int
+	index       int64
 	selfParent  string
 	otherParent string
 	name        string
@@ -307,7 +307,7 @@ func TestSee(t *testing.T) {
 func TestLamportTimestamp(t *testing.T) {
 	h, index := initPoset(t)
 
-	expectedTimestamps := map[string]int{
+	expectedTimestamps := map[string]int64{
 		"e0":  0,
 		"e1":  0,
 		"e2":  0,
@@ -522,9 +522,9 @@ func TestInsertEvent(t *testing.T) {
 		}
 
 		expectedFirstDescendants = OrderedEventCoordinates{
-			Index{participants[0].ID, EventCoordinates{"", math.MaxInt32}},
+			Index{participants[0].ID, EventCoordinates{"", math.MaxInt64}},
 			Index{participants[1].ID, EventCoordinates{index["f1"], 3}},
-			Index{participants[2].ID, EventCoordinates{"", math.MaxInt32}},
+			Index{participants[2].ID, EventCoordinates{"", math.MaxInt64}},
 		}
 
 		expectedLastAncestors = OrderedEventCoordinates{
@@ -796,7 +796,7 @@ func TestDivideRounds(t *testing.T) {
 
 	//[event] => {lamportTimestamp, round}
 	type tr struct {
-		t, r int
+		t, r int64
 	}
 	expectedTimestamps := map[string]tr{
 		"e0":  {0, 0},
@@ -1214,7 +1214,7 @@ func TestDivideRoundsBis(t *testing.T) {
 
 	//[event] => {lamportTimestamp, round}
 	type tr struct {
-		t, r int
+		t, r int64
 	}
 	expectedTimestamps := map[string]tr{
 		"e0":   {0, 0},
@@ -1539,7 +1539,7 @@ func TestKnown(t *testing.T) {
 
 	participants := h.Participants.ToPeerSlice()
 
-	expectedKnown := map[int]int{
+	expectedKnown := map[int64]int64{
 		participants[0].ID: 10,
 		participants[1].ID: 9,
 		participants[2].ID: 9,
@@ -1547,8 +1547,8 @@ func TestKnown(t *testing.T) {
 
 	known := h.Store.KnownEvents()
 	for i := range h.Participants.ToIDSlice() {
-		if l := known[i]; l != expectedKnown[i] {
-			t.Fatalf("Known[%d] should be %d, not %d", i, expectedKnown[i], l)
+		if l := known[int64(i)]; l != expectedKnown[int64(i)] {
+			t.Fatalf("Known[%d] should be %d, not %d", i, expectedKnown[int64(i)], l)
 		}
 	}
 }
@@ -1767,7 +1767,7 @@ func TestResetFromFrame(t *testing.T) {
 	*/
 
 	//Test Known
-	expectedKnown := map[int]int{
+	expectedKnown := map[int64]int64{
 		participants[0].ID: 5,
 		participants[1].ID: 4,
 		participants[2].ID: 4,
@@ -1850,7 +1850,7 @@ func TestResetFromFrame(t *testing.T) {
 	Test continue after Reset
 	***************************************************************************/
 	//Insert remaining Events into the Reset poset
-	for r := 2; r <= 4; r++ {
+	for r := int64(2); r <= int64(4); r++ {
 		round, err := h.Store.GetRound(r)
 		if err != nil {
 			t.Fatal(err)
@@ -1886,7 +1886,7 @@ func TestResetFromFrame(t *testing.T) {
 	h2.DecideRoundReceived()
 	h2.ProcessDecidedRounds()
 
-	for r := 1; r <= 4; r++ {
+	for r := int64(1); r <= 4; r++ {
 		hRound, err := h.Store.GetRound(r)
 		if err != nil {
 			t.Fatal(err)
@@ -2093,7 +2093,7 @@ func TestFunkyPosetFame(t *testing.T) {
 		t.Fatalf("last round should be 4 not %d", l)
 	}
 
-	for r := 0; r < 5; r++ {
+	for r := int64(0); r < 5; r++ {
 		round, err := h.Store.GetRound(r)
 		if err != nil {
 			t.Fatal(err)
@@ -2173,7 +2173,7 @@ func TestFunkyPosetBlocks(t *testing.T) {
 		t.Fatalf("last round should be 5 not %d", l)
 	}
 
-	for r := 0; r < 6; r++ {
+	for r := int64(0); r < 6; r++ {
 		round, err := h.Store.GetRound(r)
 		if err != nil {
 			t.Fatal(err)
@@ -2202,13 +2202,13 @@ func TestFunkyPosetBlocks(t *testing.T) {
 		}
 	}
 
-	expectedBlockTxCounts := map[int]int{
+	expectedBlockTxCounts := map[int64]int64{
 		0: 6,
 		1: 7,
 		2: 7,
 	}
 
-	for bi := 0; bi < 3; bi++ {
+	for bi := int64(0); bi < 3; bi++ {
 		b, err := h.Store.GetBlock(bi)
 		if err != nil {
 			t.Fatal(err)
@@ -2216,7 +2216,7 @@ func TestFunkyPosetBlocks(t *testing.T) {
 		for i, tx := range b.Transactions() {
 			t.Logf("block %d, tx %d: %s", bi, i, string(tx))
 		}
-		if txs := len(b.Transactions()); txs != expectedBlockTxCounts[bi] {
+		if txs := int64(len(b.Transactions())); txs != expectedBlockTxCounts[bi] {
 			t.Fatalf("Blocks[%d] should contain %d transactions, not %d", bi,
 				expectedBlockTxCounts[bi], txs)
 		}
@@ -2242,7 +2242,7 @@ func TestFunkyPosetFrames(t *testing.T) {
 	}
 
 	t.Logf("------------------------------------------------------------------")
-	for bi := 0; bi < 3; bi++ {
+	for bi := int64(0); bi < 3; bi++ {
 		block, err := h.Store.GetBlock(bi)
 		if err != nil {
 			t.Fatal(err)
@@ -2260,7 +2260,7 @@ func TestFunkyPosetFrames(t *testing.T) {
 	}
 	t.Logf("------------------------------------------------------------------")
 
-	expectedFrameRoots := map[int][]Root{
+	expectedFrameRoots := map[int64][]Root{
 		1: {
 			NewBaseRoot(participants[0].ID),
 			NewBaseRoot(participants[1].ID),
@@ -2323,7 +2323,7 @@ func TestFunkyPosetFrames(t *testing.T) {
 		},
 	}
 
-	for bi := 0; bi < 3; bi++ {
+	for bi := int64(0); bi < 3; bi++ {
 		block, err := h.Store.GetBlock(bi)
 		if err != nil {
 			t.Fatal(err)
@@ -2350,7 +2350,7 @@ func TestFunkyPosetReset(t *testing.T) {
 	h.DecideRoundReceived()
 	h.ProcessDecidedRounds()
 
-	for bi := 0; bi < 3; bi++ {
+	for bi := int64(0); bi < 3; bi++ {
 		t.Logf("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++")
 		t.Logf("RESETTING FROM BLOCK %d", bi)
 		t.Logf("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++")
@@ -2548,7 +2548,7 @@ func TestSparsePosetFrames(t *testing.T) {
 	}
 
 	t.Logf("------------------------------------------------------------------")
-	for bi := 0; bi < 3; bi++ {
+	for bi := int64(0); bi < 3; bi++ {
 		block, err := h.Store.GetBlock(bi)
 		if err != nil {
 			t.Fatal(err)
@@ -2566,7 +2566,7 @@ func TestSparsePosetFrames(t *testing.T) {
 	}
 	t.Logf("------------------------------------------------------------------")
 
-	expectedFrameRoots := map[int][]Root{
+	expectedFrameRoots := map[int64][]Root{
 		1: {
 			NewBaseRoot(participants[0].ID),
 			NewBaseRoot(participants[1].ID),
@@ -2635,7 +2635,7 @@ func TestSparsePosetFrames(t *testing.T) {
 		},
 	}
 
-	for bi := 0; bi < 3; bi++ {
+	for bi := int64(0); bi < 3; bi++ {
 		block, err := h.Store.GetBlock(bi)
 		if err != nil {
 			t.Fatal(err)
@@ -2662,7 +2662,7 @@ func TestSparsePosetReset(t *testing.T) {
 	h.DecideRoundReceived()
 	h.ProcessDecidedRounds()
 
-	for bi := 0; bi < 3; bi++ {
+	for bi := int64(0); bi < 3; bi++ {
 		t.Logf("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++")
 		t.Logf("RESETTING FROM BLOCK %d", bi)
 		t.Logf("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++")
@@ -2738,7 +2738,7 @@ func TestSparsePosetReset(t *testing.T) {
 
 /*----------------------------------------------------------------------------*/
 
-func compareRoundWitnesses(h, h2 *Poset, index map[string]string, round int, check bool, t *testing.T) {
+func compareRoundWitnesses(h, h2 *Poset, index map[string]string, round int64, check bool, t *testing.T) {
 
 	for i := round; i <= 5; i++ {
 		hRound, err := h.Store.GetRound(i)
@@ -2774,7 +2774,7 @@ func compareRoundWitnesses(h, h2 *Poset, index map[string]string, round int, che
 
 }
 
-func getDiff(h *Poset, known map[int]int, t *testing.T) []Event {
+func getDiff(h *Poset, known map[int64]int64, t *testing.T) []Event {
 	var diff []Event
 	for id, ct := range known {
 		pk := h.Participants.ById[id].PubKeyHex

--- a/src/poset/root.go
+++ b/src/poset/root.go
@@ -64,15 +64,15 @@ ex 2:
 //to allow inserting Events on top of it.
 type RootEvent struct {
 	Hash             string
-	CreatorID        int
-	Index            int
-	LamportTimestamp int
-	Round            int
+	CreatorID        int64
+	Index            int64
+	LamportTimestamp int64
+	Round            int64
 }
 
 //NewBaseRootEvent creates a RootEvent corresponding to the the very beginning
 //of a Poset.
-func NewBaseRootEvent(creatorID int) RootEvent {
+func NewBaseRootEvent(creatorID int64) RootEvent {
 	hash := fmt.Sprintf("Root%d", creatorID)
 	res := RootEvent{
 		Hash:             hash,
@@ -91,13 +91,13 @@ func NewBaseRootEvent(creatorID int) RootEvent {
 //Round; it is only used if the child's OtherParent is empty or NOT in the
 //Root's Others.
 type Root struct {
-	NextRound  int
+	NextRound  int64
 	SelfParent RootEvent
 	Others     map[string]RootEvent
 }
 
 //NewBaseRoot initializes a Root object for a fresh Poset.
-func NewBaseRoot(creatorID int) Root {
+func NewBaseRoot(creatorID int64) Root {
 	res := Root{
 		NextRound:  0,
 		SelfParent: NewBaseRootEvent(creatorID),

--- a/src/poset/roundInfo.go
+++ b/src/poset/roundInfo.go
@@ -20,7 +20,7 @@ func (t Trilean) String() string {
 }
 
 type pendingRound struct {
-	Index   int
+	Index   int64
 	Decided bool
 }
 

--- a/src/poset/store.go
+++ b/src/poset/store.go
@@ -4,7 +4,7 @@ package poset
 
 import "github.com/andrecronje/lachesis/src/peers"
 
-// Store provides an interface for persistent and non-persistent stores
+// Store provides an int64erface for persistent and non-persistent stores
 // to store key lachesis consensus information on a node.
 type Store interface {
 	CacheSize() int
@@ -12,24 +12,24 @@ type Store interface {
 	RootsBySelfParent() (map[string]Root, error)
 	GetEvent(string) (Event, error)
 	SetEvent(Event) error
-	ParticipantEvents(string, int) ([]string, error)
-	ParticipantEvent(string, int) (string, error)
+	ParticipantEvents(string, int64) ([]string, error)
+	ParticipantEvent(string, int64) (string, error)
 	LastEventFrom(string) (string, bool, error)
 	LastConsensusEventFrom(string) (string, bool, error)
-	KnownEvents() map[int]int
+	KnownEvents() map[int64]int64
 	ConsensusEvents() []string
-	ConsensusEventsCount() int
+	ConsensusEventsCount() int64
 	AddConsensusEvent(Event) error
-	GetRound(int) (RoundInfo, error)
-	SetRound(int, RoundInfo) error
-	LastRound() int
-	RoundWitnesses(int) []string
-	RoundEvents(int) int
+	GetRound(int64) (RoundInfo, error)
+	SetRound(int64, RoundInfo) error
+	LastRound() int64
+	RoundWitnesses(int64) []string
+	RoundEvents(int64) int
 	GetRoot(string) (Root, error)
-	GetBlock(int) (Block, error)
+	GetBlock(int64) (Block, error)
 	SetBlock(Block) error
-	LastBlockIndex() int
-	GetFrame(int) (Frame, error)
+	LastBlockIndex() int64
+	GetFrame(int64) (Frame, error)
 	SetFrame(Frame) error
 	Reset(map[string]Root) error
 	Close() error

--- a/src/proxy/grpc_app.go
+++ b/src/proxy/grpc_app.go
@@ -170,8 +170,8 @@ func (p *GrpcAppProxy) CommitBlock(block poset.Block) ([]byte, error) {
 }
 
 // GetSnapshot implements AppProxy interface method
-func (p *GrpcAppProxy) GetSnapshot(blockIndex int) ([]byte, error) {
-	answer, ok := <-p.push_query(int64(blockIndex))
+func (p *GrpcAppProxy) GetSnapshot(blockIndex int64) ([]byte, error) {
+	answer, ok := <-p.push_query(blockIndex)
 	if !ok {
 		return nil, ErrNoAnswers
 	}

--- a/src/proxy/grpc_lachesis.go
+++ b/src/proxy/grpc_lachesis.go
@@ -223,7 +223,7 @@ func (p *GrpcLachesisProxy) listen_events() {
 			uuid, err = xid.FromBytes(q.Uid)
 			if err == nil {
 				p.queryCh <- proto.SnapshotRequest{
-					BlockIndex: int(q.Index),
+					BlockIndex: q.Index,
 					RespChan:   p.newSnapshotResponseCh(uuid),
 				}
 			}

--- a/src/proxy/grpc_test.go
+++ b/src/proxy/grpc_test.go
@@ -71,7 +71,7 @@ func TestGrpcCalls(t *testing.T) {
 
 	t.Run("#3 Receive snapshot query", func(t *testing.T) {
 		assert := assert.New(t)
-		index := 1
+		index := int64(1)
 		gold := []byte("123456")
 
 		go func() {

--- a/src/proxy/handlers.go
+++ b/src/proxy/handlers.go
@@ -20,7 +20,7 @@ type ProxyHandler interface {
 
 	//SnapshotHandler is called by Lachesis to retrieve a snapshot corresponding to a
 	//particular block
-	SnapshotHandler(blockIndex int) (snapshot []byte, err error)
+	SnapshotHandler(blockIndex int64) (snapshot []byte, err error)
 
 	//RestoreHandler is called by Lachesis to restore the application to a specific
 	//state

--- a/src/proxy/inmem_app.go
+++ b/src/proxy/inmem_app.go
@@ -49,7 +49,7 @@ func (p *InmemAppProxy) CommitBlock(block poset.Block) ([]byte, error) {
 }
 
 // GetSnapshot implements AppProxy interface method, calls handler
-func (p *InmemAppProxy) GetSnapshot(blockIndex int) ([]byte, error) {
+func (p *InmemAppProxy) GetSnapshot(blockIndex int64) ([]byte, error) {
 	snapshot, err := p.handler.SnapshotHandler(blockIndex)
 	p.logger.WithFields(logrus.Fields{
 		"block":    blockIndex,

--- a/src/proxy/inmem_test.go
+++ b/src/proxy/inmem_test.go
@@ -97,7 +97,7 @@ func (p *TestProxy) CommitHandler(block poset.Block) ([]byte, error) {
 	return goldStateHash(), nil
 }
 
-func (p *TestProxy) SnapshotHandler(blockIndex int) ([]byte, error) {
+func (p *TestProxy) SnapshotHandler(blockIndex int64) ([]byte, error) {
 	p.logger.Debug("GetSnapshot")
 	return goldSnapshot(), nil
 }

--- a/src/proxy/proto/proto.go
+++ b/src/proxy/proto/proto.go
@@ -30,7 +30,7 @@ type SnapshotResponse struct {
 }
 // SnapshotRequest provides a response mechanism.
 type SnapshotRequest struct {
-	BlockIndex int
+	BlockIndex int64
 	RespChan   chan<- SnapshotResponse
 }
 // Respond is used to respond with a response, error or both

--- a/src/proxy/proxy.go
+++ b/src/proxy/proxy.go
@@ -10,7 +10,7 @@ import (
 type AppProxy interface {
 	SubmitCh() chan []byte
 	CommitBlock(block poset.Block) ([]byte, error)
-	GetSnapshot(blockIndex int) ([]byte, error)
+	GetSnapshot(blockIndex int64) ([]byte, error)
 	Restore(snapshot []byte) error
 }
 

--- a/src/service/service.go
+++ b/src/service/service.go
@@ -140,7 +140,7 @@ func (s *Service) GetConsensusEvents(w http.ResponseWriter, r *http.Request) {
 
 func (s *Service) GetRound(w http.ResponseWriter, r *http.Request) {
 	param := r.URL.Path[len("/round/"):]
-	roundIndex, err := strconv.Atoi(param)
+	roundIndex, err := strconv.ParseInt(param, 10, 64)
 	if err != nil {
 		s.logger.WithError(err).Errorf("Parsing roundIndex parameter %s", param)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -167,7 +167,7 @@ func (s *Service) GetLastRound(w http.ResponseWriter, r *http.Request) {
 
 func (s *Service) GetRoundWitnesses(w http.ResponseWriter, r *http.Request) {
 	param := r.URL.Path[len("/roundwitnesses/"):]
-	roundWitnessesIndex, err := strconv.Atoi(param)
+	roundWitnessesIndex, err := strconv.ParseInt(param, 10, 64)
 	if err != nil {
 		s.logger.WithError(err).Errorf("Parsing roundWitnessesIndex parameter %s", param)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -182,7 +182,7 @@ func (s *Service) GetRoundWitnesses(w http.ResponseWriter, r *http.Request) {
 
 func (s *Service) GetRoundEvents(w http.ResponseWriter, r *http.Request) {
 	param := r.URL.Path[len("/roundevents/"):]
-	roundEventsIndex, err := strconv.Atoi(param)
+	roundEventsIndex, err := strconv.ParseInt(param, 10, 64)
 	if err != nil {
 		s.logger.WithError(err).Errorf("Parsing roundEventsIndex parameter %s", param)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -210,7 +210,7 @@ func (s *Service) GetRoot(w http.ResponseWriter, r *http.Request) {
 
 func (s *Service) GetBlock(w http.ResponseWriter, r *http.Request) {
 	param := r.URL.Path[len("/block/"):]
-	blockIndex, err := strconv.Atoi(param)
+	blockIndex, err := strconv.ParseInt(param, 10, 64)
 	if err != nil {
 		s.logger.WithError(err).Errorf("Parsing block_index parameter %s", param)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -19,7 +19,7 @@ func PingNodesN(participants []*peers.Peer, p peers.PubKeyPeers, n uint64, delay
 	// make pause before shoting test transactions
 	time.Sleep(time.Duration(delay) * time.Second)
 
-	proxies := make(map[int]*proxy.GrpcLachesisProxy)
+	proxies := make(map[int64]*proxy.GrpcLachesisProxy)
 	for _, participant := range participants {
 		node := p[participant.PubKeyHex]
 		host_port := strings.Split(node.NetAddr, ":")


### PR DESCRIPTION
Why not `uint64`? Because that requires more non trivial changes, that
fail in ways I still can't understand.

Basically, the code uses the assumption that "undefined" is -1 and
"defined" is always bigger than -1. This let's you do comparisons to
check validity such as "id1 > id2."

If I change to uint64, I have to trace back each of those places and
change the logic. This is just a mere refactor, whose whole purpose it's
to allow to continue working in the protobuffer transition.

First step on #55.