### PR TITLE
int64* -> int64

### DIFF
--- a/src/node/core.go
+++ b/src/node/core.go
@@ -578,7 +578,7 @@ func (c *Core) GetConsensusTransactions() ([][]byte, error) {
 	return txs, nil
 }
 
-func (c *Core) GetLastConsensusRoundIndex() *int64 {
+func (c *Core) GetLastConsensusRoundIndex() int64 {
 	return c.poset.LastConsensusRound
 }
 

--- a/src/node/core_test.go
+++ b/src/node/core_test.go
@@ -835,12 +835,8 @@ func TestConsensusFF(t *testing.T) {
 	cores, _, _ := initCores(4, t)
 	initFFPoset(cores, t)
 
-	if r := cores[1].GetLastConsensusRoundIndex(); r == nil || *r != 1 {
-		disp := "nil"
-		if r != nil {
-			disp = strconv.FormatInt(*r, 10)
-		}
-		t.Fatalf("Cores[1] last consensus Round should be 1, not %s", disp)
+	if r := cores[1].GetLastConsensusRoundIndex(); r != 1 {
+		t.Fatalf("Cores[1] last consensus Round should be 1, not %s", strconv.FormatInt(r, 10))
 	}
 
 	if l := len(cores[1].GetConsensusEvents()); l != 6 {
@@ -903,8 +899,7 @@ func TestCoreFastForward(t *testing.T) {
 			t.Fatal(err)
 		}
 		// Assign AnchorBlock
-		cores[1].poset.AnchorBlock = new(int64)
-		*cores[1].poset.AnchorBlock = 0
+		cores[1].poset.AnchorBlock = 0
 
 		// Now the function should find an AnchorBlock
 		block, frame, err := cores[1].GetAnchorBlockWithFrame()
@@ -959,7 +954,7 @@ func TestCoreFastForward(t *testing.T) {
 			t.Fatalf("Cores[0].Known should be %v, not %v", expectedKnown, knownBy0)
 		}
 
-		if r := cores[0].GetLastConsensusRoundIndex(); r == nil || *r != 1 {
+		if r := cores[0].GetLastConsensusRoundIndex(); r != 1 {
 			t.Fatalf("Cores[0] last consensus Round should be 1, not %v", r)
 		}
 

--- a/src/node/node.go
+++ b/src/node/node.go
@@ -666,12 +666,6 @@ func (n *Node) Shutdown() {
 }
 
 func (n *Node) GetStats() map[string]string {
-	toString := func(i *int64) string {
-		if i == nil {
-			return "nil"
-		}
-		return strconv.FormatInt(*i, 10)
-	}
 
 	timeElapsed := time.Since(n.start)
 
@@ -682,12 +676,12 @@ func (n *Node) GetStats() map[string]string {
 
 	lastConsensusRound := n.core.GetLastConsensusRoundIndex()
 	var consensusRoundsPerSecond float64
-	if lastConsensusRound != nil {
-		consensusRoundsPerSecond = float64(*lastConsensusRound) / timeElapsed.Seconds()
+	if lastConsensusRound != -1 {
+		consensusRoundsPerSecond = float64(lastConsensusRound) / timeElapsed.Seconds()
 	}
 
 	s := map[string]string{
-		"last_consensus_round":    toString(lastConsensusRound),
+		"last_consensus_round":    strconv.FormatInt(lastConsensusRound, 10),
 		"time_elapsed":            strconv.FormatFloat(timeElapsed.Seconds(), 'f', 2, 64),
 		"heartbeat":               strconv.FormatFloat(n.conf.HeartbeatTimeout.Seconds(), 'f', 2, 64),
 		"node_current":            strconv.FormatInt(time.Now().Unix(), 10),

--- a/src/node/node_test.go
+++ b/src/node/node_test.go
@@ -565,7 +565,7 @@ func TestCatchUp(t *testing.T) {
 	}
 
 	start := node4.core.poset.FirstConsensusRound
-	checkGossip(nodes, *start, t)
+	checkGossip(nodes, start, t)
 }
 //
 //func TestFastSync(t *testing.T) {

--- a/src/poset/badger_store_test.go
+++ b/src/poset/badger_store_test.go
@@ -431,7 +431,7 @@ func TestDBFrameMethods(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(storedFrame, frame) {
-			t.Fatalf("Frame and StoredFrame do not match")
+			t.Fatalf("Frame and StoredFrame do not match.\nGot %#v.\nExpected %#v", storedFrame, frame)
 		}
 	})
 }

--- a/src/poset/event.go
+++ b/src/poset/event.go
@@ -104,10 +104,10 @@ type Event struct {
 	topologicalIndex int64
 
 	//used for sorting
-	round            *int64
-	lamportTimestamp *int64
+	round            int64
+	lamportTimestamp int64
 
-	roundReceived *int64
+	roundReceived int64
 
 	creator string
 	hash    []byte
@@ -135,8 +135,11 @@ func NewEvent(transactions [][]byte,
 	ft, _ := json.Marshal(flagTable)
 
 	return Event{
-		Body:      body,
-		FlagTable: ft,
+		Body:			body,
+		FlagTable:		ft,
+		round:			-1,
+		lamportTimestamp:	-1,
+		roundReceived:		-1,
 	}
 }
 
@@ -247,24 +250,15 @@ func (e *Event) Hex() string {
 }
 
 func (e *Event) SetRound(r int64) {
-	if e.round == nil {
-		e.round = new(int64)
-	}
-	*e.round = r
+	e.round = r
 }
 
 func (e *Event) SetLamportTimestamp(t int64) {
-	if e.lamportTimestamp == nil {
-		e.lamportTimestamp = new(int64)
-	}
-	*e.lamportTimestamp = t
+	e.lamportTimestamp = t
 }
 
 func (e *Event) SetRoundReceived(rr int64) {
-	if e.roundReceived == nil {
-		e.roundReceived = new(int64)
-	}
-	*e.roundReceived = rr
+	e.roundReceived = rr
 }
 
 func (e *Event) SetWireInfo(selfParentIndex,
@@ -358,11 +352,11 @@ func (a ByLamportTimestamp) Len() int      { return len(a) }
 func (a ByLamportTimestamp) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a ByLamportTimestamp) Less(i, j int) bool {
 	it, jt := int64(-1), int64(-1)
-	if a[i].lamportTimestamp != nil {
-		it = *a[i].lamportTimestamp
+	if a[i].lamportTimestamp != -1 {
+		it = a[i].lamportTimestamp
 	}
-	if a[j].lamportTimestamp != nil {
-		jt = *a[j].lamportTimestamp
+	if a[j].lamportTimestamp != -1 {
+		jt = a[j].lamportTimestamp
 	}
 	if it != jt {
 		return it < jt

--- a/src/poset/event_test.go
+++ b/src/poset/event_test.go
@@ -99,7 +99,7 @@ func TestMarshallEvent(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(*newEvent, event) {
-		t.Fatalf("Events are not deeply equal")
+		t.Fatalf("Events are not deeply equal\nGot %#v.\nExpected %#v", newEvent, event)
 	}
 }
 
@@ -183,7 +183,7 @@ func TestEventFlagTable(t *testing.T) {
 		"z": 2,
 	}
 
-	event := NewEvent(nil, nil, []string{"p1", "p2"}, []byte("creator"), 1, exp)
+	event := NewEvent(nil, nil, nil, []string{"p1", "p2"}, []byte("creator"), 1, exp)
 	if event.IsLoaded() {
 		t.Fatalf("IsLoaded() should return false for nil Body.Transactions and Body.BlockSignatures")
 	}

--- a/src/poset/frame.go
+++ b/src/poset/frame.go
@@ -29,7 +29,17 @@ func (f *Frame) Unmarshal(data []byte) error {
 
 	b := bytes.NewBuffer(data)
 	dec := json.NewDecoder(b) //will read from b
-	return dec.Decode(f)
+	err := dec.Decode(f)
+	if err != nil {
+		return err
+	}
+	for i, _ := range f.Events {
+		f.Events[i].round = -1
+		f.Events[i].roundReceived = -1
+		f.Events[i].lamportTimestamp = -1
+	}
+	
+	return nil
 }
 
 func (f *Frame) Hash() ([]byte, error) {

--- a/src/poset/inmem_store.go
+++ b/src/poset/inmem_store.go
@@ -1,7 +1,6 @@
 package poset
 
 import (
-	_ "fmt"
 	"strconv"
 
 	cm "github.com/andrecronje/lachesis/src/common"
@@ -94,18 +93,17 @@ func (s *InmemStore) SetEvent(event Event) error {
 		return err
 	}
 	if cm.Is(err, cm.KeyNotFound) {
-		if err := s.addParticpantEvent(event.Creator(), key, event.Index()); err != nil {
+		if err := s.addParticipantEvent(event.Creator(), key, event.Index()); err != nil {
 			return err
 		}
 	}
 
-	// fmt.Println("Adding event to cache", event.Hex())
 	s.eventCache.Add(key, event)
 
 	return nil
 }
 
-func (s *InmemStore) addParticpantEvent(participant string, hash string, index int64) error {
+func (s *InmemStore) addParticipantEvent(participant string, hash string, index int64) error {
 	return s.participantEventsCache.Set(participant, hash, index)
 }
 


### PR DESCRIPTION
Change all the references that use pointer to `int64` to use pure
`int64`. This is required to make the transition to protobuffer, as
there's no such a concept as pointers in the messages schema,