### PR TITLE
 Issue #55: Second step to protobuffers 

### DIFF
--- a/src/node/core_test.go
+++ b/src/node/core_test.go
@@ -285,7 +285,7 @@ func TestSync(t *testing.T) {
 	if core0Head.OtherParent() != index["e1"] {
 		t.Fatalf("core 0 head other-parent should be e1")
 	}
-	if len(core0Head.FlagTable) == 0 {
+	if len(core0Head.Message.FlagTable) == 0 {
 		t.Fatal("flag table is null")
 	}
 	index["e01"] = core0Head.Hex()

--- a/src/node/node_test.go
+++ b/src/node/node_test.go
@@ -530,7 +530,7 @@ func TestCatchUp(t *testing.T) {
 
 	target := int64(50)
 
-	err := gossip(normalNodes, target, false, 3*time.Second)
+	err := gossip(normalNodes, target, false, 4*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/poset/badger_store.go
+++ b/src/poset/badger_store.go
@@ -387,7 +387,7 @@ func (s *BadgerStore) dbSetEvents(events []Event) error {
 
 		if existent {
 			//insert [topo_index] => [event hash]
-			topoKey := topologicalEventKey(event.topologicalIndex)
+			topoKey := topologicalEventKey(event.Message.topologicalIndex)
 			if err := tx.Set(topoKey, []byte(eventHex)); err != nil {
 				return err
 			}

--- a/src/poset/badger_store_test.go
+++ b/src/poset/badger_store_test.go
@@ -169,7 +169,7 @@ func TestDBEventMethods(t *testing.T) {
 				p.pubKey,
 				k, nil)
 			event.Sign(p.privKey)
-			event.topologicalIndex = topologicalIndex
+			event.Message.topologicalIndex = topologicalIndex
 			topologicalIndex++
 			topologicalEvents = append(topologicalEvents, event)
 
@@ -189,11 +189,11 @@ func TestDBEventMethods(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !reflect.DeepEqual(ev.Body, rev.Body) {
-				t.Fatalf("events[%s][%d].Body should be %#v, not %#v", p, k, ev.Body, rev.Body)
+			if !reflect.DeepEqual(ev.Message.Body, rev.Message.Body) {
+				t.Fatalf("events[%s][%d].Body should be %#v, not %#v", p, k, ev.Message.Body, rev.Message.Body)
 			}
-			if !reflect.DeepEqual(ev.Signature, rev.Signature) {
-				t.Fatalf("events[%s][%d].Signature should be %#v, not %#v", p, k, ev.Signature, rev.Signature)
+			if !reflect.DeepEqual(ev.Message.Signature, rev.Message.Signature) {
+				t.Fatalf("events[%s][%d].Signature should be %#v, not %#v", p, k, ev.Message.Signature, rev.Message.Signature)
 			}
 			if ver, err := rev.Verify(); err != nil && !ver {
 				t.Fatalf("failed to verify signature. err: %s", err)
@@ -218,15 +218,15 @@ func TestDBEventMethods(t *testing.T) {
 				te.Hex(),
 				dte.Hex())
 		}
-		if !reflect.DeepEqual(te.Body, dte.Body) {
+		if !reflect.DeepEqual(te.Message.Body, dte.Message.Body) {
 			t.Fatalf("dbTopologicalEvents[%d].Body should be %#v, not %#v", i,
-				te.Body,
-				dte.Body)
+				te.Message.Body,
+				dte.Message.Body)
 		}
-		if !reflect.DeepEqual(te.Signature, dte.Signature) {
+		if !reflect.DeepEqual(te.Message.Signature, dte.Message.Signature) {
 			t.Fatalf("dbTopologicalEvents[%d].Signature should be %#v, not %#v", i,
-				te.Signature,
-				dte.Signature)
+				te.Message.Signature,
+				dte.Message.Signature)
 		}
 
 		if ver, err := dte.Verify(); err != nil && !ver {
@@ -474,11 +474,11 @@ func TestBadgerEvents(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !reflect.DeepEqual(ev.Body, rev.Body) {
+			if !reflect.DeepEqual(ev.Message.Body, rev.Message.Body) {
 				t.Fatalf("events[%s][%d].Body should be %#v, not %#v", p, k, ev, rev)
 			}
-			if !reflect.DeepEqual(ev.Signature, rev.Signature) {
-				t.Fatalf("events[%s][%d].Signature should be %#v, not %#v", p, k, ev.Signature, rev.Signature)
+			if !reflect.DeepEqual(ev.Message.Signature, rev.Message.Signature) {
+				t.Fatalf("events[%s][%d].Signature should be %#v, not %#v", p, k, ev.Message.Signature, rev.Message.Signature)
 			}
 		}
 	}

--- a/src/poset/event_test.go
+++ b/src/poset/event_test.go
@@ -183,7 +183,7 @@ func TestEventFlagTable(t *testing.T) {
 		"z": 2,
 	}
 
-	event := NewEvent(nil, nil, []string{"p1", "p2"}, []byte("creator"), 1, exp)
+	event := NewEvent(nil, nil, nil, []string{"p1", "p2"}, []byte("creator"), 1, exp)
 	if event.IsLoaded() {
 		t.Fatalf("IsLoaded() should return false for nil Body.Transactions and Body.BlockSignatures")
 	}

--- a/src/poset/event_test.go
+++ b/src/poset/event_test.go
@@ -62,7 +62,7 @@ func TestSignEvent(t *testing.T) {
 	body := createDummyEventBody()
 	body.Creator = publicKeyBytes
 
-	event := Event{Body: body}
+	event := Event{Message: EventMessage { Body: body} }
 	if err := event.Sign(privateKey); err != nil {
 		t.Fatalf("Error signing Event: %s", err)
 	}
@@ -83,7 +83,7 @@ func TestMarshallEvent(t *testing.T) {
 	body := createDummyEventBody()
 	body.Creator = publicKeyBytes
 
-	event := Event{Body: body}
+	event := Event{Message: EventMessage { Body: body} }
 	if err := event.Sign(privateKey); err != nil {
 		t.Fatalf("Error signing Event: %s", err)
 	}
@@ -110,7 +110,7 @@ func TestWireEvent(t *testing.T) {
 	body := createDummyEventBody()
 	body.Creator = publicKeyBytes
 
-	event := Event{Body: body}
+	event := Event{Message: EventMessage { Body: body} }
 	if err := event.Sign(privateKey); err != nil {
 		t.Fatalf("Error signing Event: %s", err)
 	}
@@ -119,16 +119,16 @@ func TestWireEvent(t *testing.T) {
 
 	expectedWireEvent := WireEvent{
 		Body: WireBody{
-			Transactions:         event.Body.Transactions,
-			InternalTransactions: event.Body.InternalTransactions,
+			Transactions:         event.Message.Body.Transactions,
+			InternalTransactions: event.Message.Body.InternalTransactions,
 			SelfParentIndex:      1,
 			OtherParentCreatorID: 66,
 			OtherParentIndex:     2,
 			CreatorID:            67,
-			Index:                event.Body.Index,
+			Index:                event.Message.Body.Index,
 			BlockSignatures:      event.WireBlockSignatures(),
 		},
-		Signature: event.Signature,
+		Signature: event.Message.Signature,
 	}
 
 	wireEvent := event.ToWire()
@@ -146,31 +146,31 @@ func TestIsLoaded(t *testing.T) {
 	}
 
 	//empty payload
-	event.Body.Transactions = [][]byte{}
+	event.Message.Body.Transactions = [][]byte{}
 	if event.IsLoaded() {
 		t.Fatalf("IsLoaded() should return false for empty Body.Transactions")
 	}
 
-	event.Body.BlockSignatures = []BlockSignature{}
+	event.Message.Body.BlockSignatures = []BlockSignature{}
 	if event.IsLoaded() {
 		t.Fatalf("IsLoaded() should return false for empty Body.BlockSignatures")
 	}
 
 	//initial event
-	event.Body.Index = 0
+	event.Message.Body.Index = 0
 	if !event.IsLoaded() {
 		t.Fatalf("IsLoaded() should return true for initial event")
 	}
 
 	//non-empty tx payload
-	event.Body.Transactions = [][]byte{[]byte("abc")}
+	event.Message.Body.Transactions = [][]byte{[]byte("abc")}
 	if !event.IsLoaded() {
 		t.Fatalf("IsLoaded() should return true for non-empty transaction payload")
 	}
 
 	//non-empy signature payload
-	event.Body.Transactions = nil
-	event.Body.BlockSignatures = []BlockSignature{{Validator: []byte("validator"), Index: 0, Signature: "r|s"}}
+	event.Message.Body.Transactions = nil
+	event.Message.Body.BlockSignatures = []BlockSignature{{Validator: []byte("validator"), Index: 0, Signature: "r|s"}}
 	if !event.IsLoaded() {
 		t.Fatalf("IsLoaded() should return true for non-empty signature payload")
 	}
@@ -188,7 +188,7 @@ func TestEventFlagTable(t *testing.T) {
 		t.Fatalf("IsLoaded() should return false for nil Body.Transactions and Body.BlockSignatures")
 	}
 
-	if len(event.FlagTable) == 0 {
+	if len(event.Message.FlagTable) == 0 {
 		t.Fatal("FlagTable is nil")
 	}
 
@@ -229,7 +229,7 @@ func TestMergeFlagTable(t *testing.T) {
 	}
 
 	ft, _ := json.Marshal(start)
-	event := Event{FlagTable: ft}
+	event := Event{Message: EventMessage { FlagTable: ft} }
 
 	for _, v := range syncData {
 		flagTable, err := event.MergeFlagTable(v)
@@ -238,11 +238,11 @@ func TestMergeFlagTable(t *testing.T) {
 		}
 
 		raw, _ := json.Marshal(flagTable)
-		event.FlagTable = raw
+		event.Message.FlagTable = raw
 	}
 
 	var res map[string]int64
-	json.Unmarshal(event.FlagTable, &res)
+	json.Unmarshal(event.Message.FlagTable, &res)
 
 	if !reflect.DeepEqual(exp, res) {
 		t.Fatalf("expected flag table: %+v, got: %+v", exp, res)

--- a/src/poset/inmem_store_test.go
+++ b/src/poset/inmem_store_test.go
@@ -68,7 +68,7 @@ func TestInmemEvents(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if !reflect.DeepEqual(ev.Body, rev.Body) {
+				if !reflect.DeepEqual(ev.Message.Body, rev.Message.Body) {
 					t.Fatalf("events[%s][%d] should be %#v, not %#v", p, k, ev, rev)
 				}
 			}

--- a/src/poset/poset.go
+++ b/src/poset/poset.go
@@ -765,7 +765,7 @@ func (p *Poset) InsertEvent(event Event, setWireInfo bool) error {
 		return fmt.Errorf("CheckOtherParent: %s", err)
 	}
 
-	event.topologicalIndex = p.topologicalIndex
+	event.Message.topologicalIndex = p.topologicalIndex
 	p.topologicalIndex++
 
 	if setWireInfo {
@@ -1519,13 +1519,15 @@ func (p *Poset) ReadWireInfo(wevent WireEvent) (*Event, error) {
 	}
 
 	event := &Event{
-		Body:      body,
-		Signature: wevent.Signature,
-		FlagTable: wevent.FlagTable,
+		Message: EventMessage {
+			Body:      body,
+			Signature: wevent.Signature,
+			FlagTable: wevent.FlagTable,
+		},
 	}
 
 	p.logger.WithFields(logrus.Fields{
-		"event.Signature": event.Signature,
+		"event.Signature": event.Message.Signature,
 		"wevent.Signature":  wevent.Signature,
 	}).Debug("Return Event from ReadFromWire")
 

--- a/src/poset/poset_test.go
+++ b/src/poset/poset_test.go
@@ -501,7 +501,7 @@ func TestInsertEvent(t *testing.T) {
 			t.Fatalf("Invalid wire info on f1")
 		}
 
-		e0CreatorID := strconv.Itoa(p.Participants.ByPubKey[e0.Creator()].ID)
+		e0CreatorID := strconv.FormatInt(p.Participants.ByPubKey[e0.Creator()].ID, 10)
 
 		type Hierarchy struct {
 			ev, selfAncestor, ancestor string

--- a/src/poset/poset_test.go
+++ b/src/poset/poset_test.go
@@ -463,10 +463,10 @@ func TestInsertEvent(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !(e0.Body.selfParentIndex == -1 &&
-			e0.Body.otherParentCreatorID == -1 &&
-			e0.Body.otherParentIndex == -1 &&
-			e0.Body.creatorID == p.Participants.ByPubKey[e0.Creator()].ID) {
+		if !(e0.Message.Body.selfParentIndex == -1 &&
+			e0.Message.Body.otherParentCreatorID == -1 &&
+			e0.Message.Body.otherParentIndex == -1 &&
+			e0.Message.Body.creatorID == p.Participants.ByPubKey[e0.Creator()].ID) {
 			t.Fatalf("Invalid wire info on e0")
 		}
 
@@ -481,10 +481,10 @@ func TestInsertEvent(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !(e21.Body.selfParentIndex == 1 &&
-			e21.Body.otherParentCreatorID == p.Participants.ByPubKey[e10.Creator()].ID &&
-			e21.Body.otherParentIndex == 1 &&
-			e21.Body.creatorID == p.Participants.ByPubKey[e21.Creator()].ID) {
+		if !(e21.Message.Body.selfParentIndex == 1 &&
+			e21.Message.Body.otherParentCreatorID == p.Participants.ByPubKey[e10.Creator()].ID &&
+			e21.Message.Body.otherParentIndex == 1 &&
+			e21.Message.Body.creatorID == p.Participants.ByPubKey[e21.Creator()].ID) {
 			t.Fatalf("Invalid wire info on e21")
 		}
 
@@ -494,10 +494,10 @@ func TestInsertEvent(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !(f1.Body.selfParentIndex == 2 &&
-			f1.Body.otherParentCreatorID == p.Participants.ByPubKey[e0.Creator()].ID &&
-			f1.Body.otherParentIndex == 2 &&
-			f1.Body.creatorID == p.Participants.ByPubKey[f1.Creator()].ID) {
+		if !(f1.Message.Body.selfParentIndex == 2 &&
+			f1.Message.Body.otherParentCreatorID == p.Participants.ByPubKey[e0.Creator()].ID &&
+			f1.Message.Body.otherParentIndex == 2 &&
+			f1.Message.Body.creatorID == p.Participants.ByPubKey[f1.Creator()].ID) {
 			t.Fatalf("Invalid wire info on f1")
 		}
 
@@ -572,15 +572,15 @@ func TestReadWireInfo(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !reflect.DeepEqual(ev.Body.BlockSignatures, evFromWire.Body.BlockSignatures) {
+		if !reflect.DeepEqual(ev.Message.Body.BlockSignatures, evFromWire.Message.Body.BlockSignatures) {
 			t.Fatalf("Error converting %s.Body.BlockSignatures from light wire", k)
 		}
 
-		if !reflect.DeepEqual(ev.Body, evFromWire.Body) {
+		if !reflect.DeepEqual(ev.Message.Body, evFromWire.Message.Body) {
 			t.Fatalf("Error converting %s.Body from light wire", k)
 		}
 
-		if !reflect.DeepEqual(ev.Signature, evFromWire.Signature) {
+		if !reflect.DeepEqual(ev.Message.Signature, evFromWire.Message.Signature) {
 			t.Fatalf("Error converting %s.Signature from light wire", k)
 		}
 
@@ -2711,8 +2711,8 @@ func TestSparsePosetReset(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ReadWireInfo(%s): %s", eventName, err)
 			}
-			if !reflect.DeepEqual(ev.Body, diff[i].Body) {
-				t.Fatalf("%s from WireInfo should be %#v, not %#v", eventName, diff[i].Body, ev.Body)
+			if !reflect.DeepEqual(ev.Message.Body, diff[i].Message.Body) {
+				t.Fatalf("%s from WireInfo should be %#v, not %#v", eventName, diff[i].Message.Body, ev.Message.Body)
 			}
 			err = p2.InsertEvent(*ev, false)
 			if err != nil {


### PR DESCRIPTION
Sending pointers through protobuffer it's not possible. That's a
problem, because one of the structures we have to transmit, `Event`, has
some internal private state saved as pointers.

Initially, I tried to change it to plain integers. That failed
misserably for misterious (and unknown) reasons.

So I decided to take another approache: Apply good OOP practices and
divide `Event` in two. One, the wrapper, contains the internal state and
the message to be marshelled. The message, contains only the fields that
will be transmitted through the network.

That way, we don't have to marshall anything with pointers.