### PR TITLE
use lachesis.Peers instead of Store.Participants()

### DIFF
--- a/cmd/lachesis/commands/run.go
+++ b/cmd/lachesis/commands/run.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/urfave/cli"
 )
 
 //NewRunCmd returns the command that starts a Lachesis node
@@ -88,12 +87,7 @@ func runSingleLachesis(config *CLIConfig) error {
 	}
 
 	if config.Lachesis.Test {
-		p, err := engine.Store.Participants()
-		if err != nil {
-			return cli.NewExitError(
-				fmt.Sprintf("Failed to acquire participants: %s", err),
-				1)
-		}
+		p := engine.Peers
 		go func() {
 			for {
 				time.Sleep(10 * time.Second)


### PR DESCRIPTION
use lachesis.Peers instead of Store.Participants() as the latter one doesn't stored NetAddr field of peer.